### PR TITLE
Feature implementation from commits ab2d6a4..9e84b8d

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -1,0 +1,63 @@
+name: 'Build Image'
+description: 'Composite action which combines all steps necessary to build the LocalStack Community image.'
+inputs:
+  dockerhubPullUsername:
+    description: 'Username to log in to DockerHub to mitigate rate limiting issues with DockerHub.'
+    required: false
+  dockerhubPullToken:
+    description: 'API token to log in to DockerHub to mitigate rate limiting issues with DockerHub.'
+    required: false
+  disableCaching:
+    description: 'Disable Caching'
+    required: false
+outputs:
+  image-artifact-name:
+    description: "Name of the artifact containing the built docker image"
+    value: ${{ steps.image-artifact-name.outputs.image-artifact-name }}
+runs:
+  using: "composite"
+  # This GH Action requires localstack repo in 'localstack' dir + full git history (fetch-depth: 0)
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: 'localstack/.python-version'
+
+    - name: Install docker helper dependencies
+      shell: bash
+      run: pip install --upgrade setuptools setuptools_scm
+
+    - name: Login to Docker Hub
+      # login to DockerHub to avoid rate limiting issues on custom runners
+      uses: docker/login-action@v3
+      if: ${{ inputs.dockerHubPullUsername != '' && inputs.dockerHubPullToken != '' }}
+      with:
+        username: ${{ inputs.dockerhubPullUsername }}
+        password: ${{ inputs.dockerhubPullToken }}
+
+    - name: Build Docker Image
+      id: build-image
+      shell: bash
+      env:
+        DOCKER_BUILD_FLAGS: "--load ${{ inputs.disableCaching == 'true' && '--no-cache' || '' }}"
+        PLATFORM: ${{ (runner.arch == 'X64' && 'amd64') || (runner.arch == 'ARM64' && 'arm64') || '' }}
+        DOCKERFILE: ../Dockerfile
+        DOCKER_BUILD_CONTEXT: ..
+        IMAGE_NAME: "localstack/localstack"
+      working-directory: localstack/localstack-core
+      run: |
+        ../bin/docker-helper.sh build
+        ../bin/docker-helper.sh save
+
+    - name: Store Docker Image as Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: localstack-docker-image-${{ (runner.arch == 'X64' && 'amd64') || (runner.arch == 'ARM64' && 'arm64') || '' }}
+        # the path is defined by the "save" command of the docker-helper, which sets a GitHub output "IMAGE_FILENAME"
+        path: localstack/localstack-core/${{ steps.build-image.outputs.IMAGE_FILENAME || steps.build-test-image.outputs.IMAGE_FILENAME}}
+        retention-days: 1
+
+    - name: Set image artifact name as output
+      id: image-artifact-name
+      shell: bash
+      run: echo "image-artifact-name=localstack-docker-image-${{ (runner.arch == 'X64' && 'amd64') || (runner.arch == 'ARM64' && 'arm64') || '' }}" >> $GITHUB_OUTPUT

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.4
+    rev: v0.11.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # base: Stage which installs necessary runtime dependencies (OS packages, etc.)
 #
-FROM python:3.11.11-slim-bookworm@sha256:7029b00486ac40bed03e36775b864d3f3d39dcbdf19cd45e6a52d541e6c178f0 AS base
+FROM python:3.11.12-slim-bookworm@sha256:82c07f2f6e35255b92eb16f38dbd22679d5e8fb523064138d7c6468e7bf0c15b AS base
 ARG TARGETARCH
 
 # Install runtime OS package dependencies

--- a/Dockerfile.s3
+++ b/Dockerfile.s3
@@ -1,5 +1,5 @@
 # base: Stage which installs necessary runtime dependencies (OS packages, filesystem...)
-FROM python:3.11.11-slim-bookworm@sha256:7029b00486ac40bed03e36775b864d3f3d39dcbdf19cd45e6a52d541e6c178f0 AS base
+FROM python:3.11.12-slim-bookworm@sha256:82c07f2f6e35255b92eb16f38dbd22679d5e8fb523064138d7c6468e7bf0c15b AS base
 ARG TARGETARCH
 
 # set workdir

--- a/localstack-core/localstack/cli/main.py
+++ b/localstack-core/localstack/cli/main.py
@@ -6,9 +6,10 @@ def main():
     os.environ["LOCALSTACK_CLI"] = "1"
 
     # config profiles are the first thing that need to be loaded (especially before localstack.config!)
-    from .profiles import set_profile_from_sys_argv
+    from .profiles import set_and_remove_profile_from_sys_argv
 
-    set_profile_from_sys_argv()
+    # WARNING: This function modifies sys.argv to remove the profile argument.
+    set_and_remove_profile_from_sys_argv()
 
     # initialize CLI plugins
     from .localstack import create_with_plugins

--- a/localstack-core/localstack/cli/profiles.py
+++ b/localstack-core/localstack/cli/profiles.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 from typing import Optional
@@ -5,36 +6,61 @@ from typing import Optional
 # important: this needs to be free of localstack imports
 
 
-def set_profile_from_sys_argv():
+def set_and_remove_profile_from_sys_argv():
     """
-    Reads the --profile flag from sys.argv and then sets the 'CONFIG_PROFILE' os variable accordingly. This is later
-    picked up by ``localstack.config``.
+    Performs the following steps:
+
+    1. Use argparse to parse the command line arguments for the --profile flag.
+       All occurrences are removed from the sys.argv list, and the value from
+       the last occurrence is used.  This allows the user to specify a profile
+       at any point on the command line.
+
+    2. If a --profile flag is not found, check for the -p flag.  The first
+       occurrence of the -p flag is used and it is not removed from sys.argv.
+       The reasoning for this is that at least one of the CLI subcommands has
+       a -p flag, and we want to keep it in sys.argv for that command to
+       pick up.  An existing bug means that if a -p flag is used with a
+       subcommand, it could erroneously be used as the profile value as well.
+       This behaviour is undesired, but we must maintain back-compatibility of
+       allowing the profile to be specified using -p.
+
+    3. If a profile is found, the 'CONFIG_PROFILE' os variable is set
+       accordingly. This is later picked up by ``localstack.config``.
+
+    WARNING:  Any --profile options are REMOVED from sys.argv, so that they are
+              not passed to the localstack CLI. This allows the profile option
+              to be set at any point on the command line.
     """
-    profile = parse_profile_argument(sys.argv)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile")
+    namespace, sys.argv = parser.parse_known_args(sys.argv)
+    profile = namespace.profile
+
+    if not profile:
+        # if no profile is given, check for the -p argument
+        profile = parse_p_argument(sys.argv)
+
     if profile:
         os.environ["CONFIG_PROFILE"] = profile.strip()
 
 
-def parse_profile_argument(args) -> Optional[str]:
+def parse_p_argument(args) -> Optional[str]:
     """
-    Lightweight arg parsing to find ``--profile <config>``, or ``--profile=<config>`` and return the value of
+    Lightweight arg parsing to find the first occurrence of ``-p <config>``, or ``-p=<config>`` and return the value of
     ``<config>`` from the given arguments.
 
     :param args: list of CLI arguments
-    :returns: the value of ``--profile``.
+    :returns: the value of ``-p``.
     """
     for i, current_arg in enumerate(args):
-        if current_arg.startswith("--profile="):
-            # if using the "<arg>=<value>" notation, we remove the "--profile=" prefix to get the value
-            return current_arg[10:]
-        elif current_arg.startswith("-p="):
+        if current_arg.startswith("-p="):
             # if using the "<arg>=<value>" notation, we remove the "-p=" prefix to get the value
             return current_arg[3:]
-        if current_arg in ["--profile", "-p"]:
+        if current_arg == "-p":
             # otherwise use the next arg in the args list as value
             try:
                 return args[i + 1]
-            except KeyError:
+            except IndexError:
                 return None
 
     return None

--- a/localstack-core/localstack/services/apigateway/helpers.py
+++ b/localstack-core/localstack/services/apigateway/helpers.py
@@ -3,7 +3,6 @@ import copy
 import hashlib
 import json
 import logging
-from datetime import datetime
 from typing import List, Optional, TypedDict, Union
 from urllib import parse as urlparse
 
@@ -60,7 +59,6 @@ INVOKE_TEST_LOG_TEMPLATE = """Execution log for request {request_id}
         {formatted_date} : Successfully completed execution
         {formatted_date} : Method completed with status: {status_code}
         """
-
 
 EMPTY_MODEL = "Empty"
 ERROR_MODEL = "Error"
@@ -982,35 +980,6 @@ def is_greedy_path(path_part: str) -> bool:
 
 def is_variable_path(path_part: str) -> bool:
     return path_part.startswith("{") and path_part.endswith("}")
-
-
-def log_template(
-    request_id: str,
-    date: datetime,
-    http_method: str,
-    resource_path: str,
-    request_path: str,
-    query_string: str,
-    request_headers: str,
-    request_body: str,
-    response_body: str,
-    response_headers: str,
-    status_code: str,
-):
-    formatted_date = date.strftime("%a %b %d %H:%M:%S %Z %Y")
-    return INVOKE_TEST_LOG_TEMPLATE.format(
-        request_id=request_id,
-        formatted_date=formatted_date,
-        http_method=http_method,
-        resource_path=resource_path,
-        request_path=request_path,
-        query_string=query_string,
-        request_headers=request_headers,
-        request_body=request_body,
-        response_body=response_body,
-        response_headers=response_headers,
-        status_code=status_code,
-    )
 
 
 def get_domain_name_hash(domain_name: str) -> str:

--- a/localstack-core/localstack/services/apigateway/legacy/provider.py
+++ b/localstack-core/localstack/services/apigateway/legacy/provider.py
@@ -98,6 +98,7 @@ from localstack.services.apigateway.exporter import OpenApiExporter
 from localstack.services.apigateway.helpers import (
     EMPTY_MODEL,
     ERROR_MODEL,
+    INVOKE_TEST_LOG_TEMPLATE,
     OpenAPIExt,
     apply_json_patch_safe,
     get_apigateway_store,
@@ -108,7 +109,6 @@ from localstack.services.apigateway.helpers import (
     import_api_from_openapi_spec,
     is_greedy_path,
     is_variable_path,
-    log_template,
     resolve_references,
 )
 from localstack.services.apigateway.legacy.helpers import multi_value_dict_for_list
@@ -217,9 +217,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         # TODO: add the missing fields to the log. Next iteration will add helpers to extract the missing fields
         # from the apicontext
-        log = log_template(
+        formatted_date = req_start_time.strftime("%a %b %d %H:%M:%S %Z %Y")
+        log = INVOKE_TEST_LOG_TEMPLATE.format(
             request_id=invocation_context.context["requestId"],
-            date=req_start_time,
+            formatted_date=formatted_date,
             http_method=invocation_context.method,
             resource_path=invocation_context.invocation_path,
             request_path="",
@@ -230,6 +231,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             response_headers=result.headers,
             status_code=result.status_code,
         )
+
         return TestInvokeMethodResponse(
             status=result.status_code,
             headers=dict(result.headers),

--- a/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
+++ b/localstack-core/localstack/services/apigateway/next_gen/execute_api/test_invoke.py
@@ -1,0 +1,206 @@
+import datetime
+from urllib.parse import parse_qs
+
+from rolo import Request
+from rolo.gateway.chain import HandlerChain
+from werkzeug.datastructures import Headers
+
+from localstack.aws.api.apigateway import TestInvokeMethodRequest, TestInvokeMethodResponse
+from localstack.constants import APPLICATION_JSON
+from localstack.http import Response
+from localstack.utils.strings import to_bytes, to_str
+
+from ...models import RestApiDeployment
+from . import handlers
+from .context import InvocationRequest, RestApiInvocationContext
+from .handlers.resource_router import RestAPIResourceRouter
+from .header_utils import build_multi_value_headers
+from .template_mapping import dict_to_string
+
+# TODO: we probably need to write and populate those logs as part of the handler chain itself
+#  and store it in the InvocationContext. That way, we could also retrieve in when calling TestInvoke
+
+TEST_INVOKE_TEMPLATE = """Execution log for request {request_id}
+{formatted_date} : Starting execution for request: {request_id}
+{formatted_date} : HTTP Method: {request_method}, Resource Path: {resource_path}
+{formatted_date} : Method request path: {method_request_path_parameters}
+{formatted_date} : Method request query string: {method_request_query_string}
+{formatted_date} : Method request headers: {method_request_headers}
+{formatted_date} : Method request body before transformations: {method_request_body}
+{formatted_date} : Endpoint request URI: {endpoint_uri}
+{formatted_date} : Endpoint request headers: {endpoint_request_headers}
+{formatted_date} : Endpoint request body after transformations: {endpoint_request_body}
+{formatted_date} : Sending request to {endpoint_uri}
+{formatted_date} : Received response. Status: {endpoint_response_status_code}, Integration latency: {endpoint_response_latency} ms
+{formatted_date} : Endpoint response headers: {endpoint_response_headers}
+{formatted_date} : Endpoint response body before transformations: {endpoint_response_body}
+{formatted_date} : Method response body after transformations: {method_response_body}
+{formatted_date} : Method response headers: {method_response_headers}
+{formatted_date} : Successfully completed execution
+{formatted_date} : Method completed with status: {method_response_status}
+"""
+
+
+def _dump_headers(headers: Headers) -> str:
+    if not headers:
+        return "{}"
+    multi_headers = {key: ",".join(headers.getlist(key)) for key in headers.keys()}
+    string_headers = dict_to_string(multi_headers)
+    if len(string_headers) > 998:
+        return f"{string_headers[:998]} [TRUNCATED]"
+
+    return string_headers
+
+
+def log_template(invocation_context: RestApiInvocationContext, response_headers: Headers) -> str:
+    # TODO: funny enough, in AWS for the `endpoint_response_headers` in AWS_PROXY, they log the response headers from
+    #  lambda HTTP Invoke call even though we use the headers from the lambda response itself
+    formatted_date = datetime.datetime.now(tz=datetime.UTC).strftime("%a %b %d %H:%M:%S %Z %Y")
+    request = invocation_context.invocation_request
+    context_var = invocation_context.context_variables
+    integration_req = invocation_context.integration_request
+    endpoint_resp = invocation_context.endpoint_response
+    method_resp = invocation_context.invocation_response
+    # TODO: if endpoint_uri is an ARN, it means it's an AWS_PROXY integration
+    #  this should be transformed to the true URL of a lambda invoke call
+    endpoint_uri = integration_req.get("uri", "")
+
+    return TEST_INVOKE_TEMPLATE.format(
+        formatted_date=formatted_date,
+        request_id=context_var["requestId"],
+        resource_path=request["path"],
+        request_method=request["http_method"],
+        method_request_path_parameters=dict_to_string(request["path_parameters"]),
+        method_request_query_string=dict_to_string(request["query_string_parameters"]),
+        method_request_headers=_dump_headers(request.get("headers")),
+        method_request_body=to_str(request.get("body", "")),
+        endpoint_uri=endpoint_uri,
+        endpoint_request_headers=_dump_headers(integration_req.get("headers")),
+        endpoint_request_body=to_str(integration_req.get("body", "")),
+        # TODO: measure integration latency
+        endpoint_response_latency=150,
+        endpoint_response_status_code=endpoint_resp.get("status_code"),
+        endpoint_response_body=to_str(endpoint_resp.get("body", "")),
+        endpoint_response_headers=_dump_headers(endpoint_resp.get("headers")),
+        method_response_status=method_resp.get("status_code"),
+        method_response_body=to_str(method_resp.get("body", "")),
+        method_response_headers=_dump_headers(response_headers),
+    )
+
+
+def create_test_chain() -> HandlerChain[RestApiInvocationContext]:
+    return HandlerChain(
+        request_handlers=[
+            handlers.method_request_handler,
+            handlers.integration_request_handler,
+            handlers.integration_handler,
+            handlers.integration_response_handler,
+            handlers.method_response_handler,
+        ],
+        exception_handlers=[
+            handlers.gateway_exception_handler,
+        ],
+    )
+
+
+def create_test_invocation_context(
+    test_request: TestInvokeMethodRequest,
+    deployment: RestApiDeployment,
+) -> RestApiInvocationContext:
+    parse_handler = handlers.parse_request
+    http_method = test_request["httpMethod"]
+
+    # we do not need a true HTTP request for the context, as we are skipping all the parsing steps and using the
+    # provider data
+    invocation_context = RestApiInvocationContext(
+        request=Request(method=http_method),
+    )
+    path_query = test_request.get("pathWithQueryString", "/").split("?")
+    path = path_query[0]
+    multi_query_args: dict[str, list[str]] = {}
+
+    if len(path_query) > 1:
+        multi_query_args = parse_qs(path_query[1])
+
+    # for the single value parameters, AWS only keeps the last value of the list
+    single_query_args = {k: v[-1] for k, v in multi_query_args.items()}
+
+    invocation_request = InvocationRequest(
+        http_method=http_method,
+        path=path,
+        raw_path=path,
+        query_string_parameters=single_query_args,
+        multi_value_query_string_parameters=multi_query_args,
+        headers=Headers(test_request.get("headers")),
+        # TODO: handle multiValueHeaders
+        body=to_bytes(test_request.get("body") or ""),
+    )
+    invocation_context.invocation_request = invocation_request
+
+    _, path_parameters = RestAPIResourceRouter(deployment).match(invocation_context)
+    invocation_request["path_parameters"] = path_parameters
+
+    invocation_context.deployment = deployment
+    invocation_context.api_id = test_request["restApiId"]
+    invocation_context.stage = None
+    invocation_context.deployment_id = ""
+    invocation_context.account_id = deployment.account_id
+    invocation_context.region = deployment.region
+    invocation_context.stage_variables = test_request.get("stageVariables", {})
+    invocation_context.context_variables = parse_handler.create_context_variables(
+        invocation_context
+    )
+    invocation_context.trace_id = parse_handler.populate_trace_id({})
+
+    resource = deployment.rest_api.resources[test_request["resourceId"]]
+    resource_method = resource["resourceMethods"][http_method]
+    invocation_context.resource = resource
+    invocation_context.resource_method = resource_method
+    invocation_context.integration = resource_method["methodIntegration"]
+    handlers.route_request.update_context_variables_with_resource(
+        invocation_context.context_variables, resource
+    )
+
+    return invocation_context
+
+
+def run_test_invocation(
+    test_request: TestInvokeMethodRequest, deployment: RestApiDeployment
+) -> TestInvokeMethodResponse:
+    # validate resource exists in deployment
+    invocation_context = create_test_invocation_context(test_request, deployment)
+
+    test_chain = create_test_chain()
+    # header order is important
+    if invocation_context.integration["type"] == "MOCK":
+        base_headers = {"Content-Type": APPLICATION_JSON}
+    else:
+        # we manually add the trace-id, as it is normally added by handlers.response_enricher which adds to much data
+        # for the TestInvoke. It needs to be first
+        base_headers = {
+            "X-Amzn-Trace-Id": invocation_context.trace_id,
+            "Content-Type": APPLICATION_JSON,
+        }
+
+    test_response = Response(headers=base_headers)
+    start_time = datetime.datetime.now()
+    test_chain.handle(context=invocation_context, response=test_response)
+    end_time = datetime.datetime.now()
+
+    response_headers = test_response.headers.copy()
+    # AWS does not return the Content-Length for TestInvokeMethod
+    response_headers.remove("Content-Length")
+
+    log = log_template(invocation_context, response_headers)
+
+    headers = dict(response_headers)
+    multi_value_headers = build_multi_value_headers(response_headers)
+
+    return TestInvokeMethodResponse(
+        log=log,
+        status=test_response.status_code,
+        body=test_response.get_data(as_text=True),
+        headers=headers,
+        multiValueHeaders=multi_value_headers,
+        latency=int((end_time - start_time).total_seconds()),
+    )

--- a/localstack-core/localstack/services/cloudformation/engine/entities.py
+++ b/localstack-core/localstack/services/cloudformation/engine/entities.py
@@ -49,7 +49,7 @@ class StackInstance:
         self.stack = None
 
 
-class StackMetadata(TypedDict):
+class CreateChangeSetInput(TypedDict):
     StackName: str
     Capabilities: list[Capability]
     ChangeSetName: Optional[str]
@@ -83,7 +83,7 @@ class Stack:
         self,
         account_id: str,
         region_name: str,
-        metadata: Optional[StackMetadata] = None,
+        metadata: Optional[CreateChangeSetInput] = None,
         template: Optional[StackTemplate] = None,
         template_body: Optional[str] = None,
     ):

--- a/localstack-core/localstack/services/cloudformation/engine/quirks.py
+++ b/localstack-core/localstack/services/cloudformation/engine/quirks.py
@@ -30,6 +30,9 @@ PHYSICAL_RESOURCE_ID_SPECIAL_CASES = {
     "AWS::Logs::SubscriptionFilter": "/properties/LogGroupName",
     "AWS::RDS::DBProxyTargetGroup": "/properties/TargetGroupName",
     "AWS::Glue::SchemaVersionMetadata": "</properties/SchemaVersionId>|</properties/Key>|</properties/Value>",  # composite
+    "AWS::VerifiedPermissions::IdentitySource": "</properties/IdentitySourceId>|</properties/PolicyStoreId>",  # composite
+    "AWS::VerifiedPermissions::Policy": "</properties/PolicyId>|</properties/PolicyStoreId>",  # composite
+    "AWS::VerifiedPermissions::PolicyTemplate": "</properties/PolicyStoreId>|</properties/PolicyTemplateId>",  # composite
     "AWS::WAFv2::WebACL": "</properties/Name>|</properties/Id>|</properties/Scope>",
     "AWS::WAFv2::WebACLAssociation": "</properties/ResourceArn>|</properties/WebACLArn>",
     "AWS::WAFv2::IPSet": "</properties/Name>|</properties/Id>|</properties/Scope>",

--- a/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/template_deployer.py
@@ -35,7 +35,6 @@ from localstack.services.cloudformation.resource_provider import (
     ProgressEvent,
     ResourceProviderExecutor,
     ResourceProviderPayload,
-    get_resource_type,
 )
 from localstack.services.cloudformation.service_models import (
     DependencyNotYetSatisfied,
@@ -364,7 +363,7 @@ def _resolve_refs_recursively(
             )
             resource = resources.get(resource_logical_id)
 
-            resource_type = get_resource_type(resource)
+            resource_type = resource["Type"]
             resolved_getatt = get_attr_from_model_instance(
                 resource,
                 attribute_name,
@@ -812,7 +811,7 @@ def resolve_placeholders_in_string(
             resolved = get_attr_from_model_instance(
                 resources[logical_resource_id],
                 attr_name,
-                get_resource_type(resources[logical_resource_id]),
+                resources[logical_resource_id]["Type"],
                 logical_resource_id,
             )
             if resolved is None:
@@ -1295,7 +1294,7 @@ class TemplateDeployer:
             action, logical_resource_id=resource_id
         )
 
-        resource_provider = executor.try_load_resource_provider(get_resource_type(resource))
+        resource_provider = executor.try_load_resource_provider(resource["Type"])
         if resource_provider is not None:
             # add in-progress event
             resource_status = f"{get_action_name_for_resource_change(action)}_IN_PROGRESS"
@@ -1407,7 +1406,7 @@ class TemplateDeployer:
             resource["Properties"] = resource.get(
                 "Properties", clone_safe(resource)
             )  # TODO: why is there a fallback?
-            resource["ResourceType"] = get_resource_type(resource)
+            resource["ResourceType"] = resource["Type"]
 
         ordered_resource_ids = list(
             order_resources(
@@ -1438,7 +1437,7 @@ class TemplateDeployer:
                     len(resources),
                     resource["ResourceType"],
                 )
-                resource_provider = executor.try_load_resource_provider(get_resource_type(resource))
+                resource_provider = executor.try_load_resource_provider(resource["Type"])
                 if resource_provider is not None:
                     event = executor.deploy_loop(
                         resource_provider, resource, resource_provider_payload

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model.py
@@ -769,7 +769,10 @@ class ChangeSetModel:
             before_properties=before_properties,
             after_properties=after_properties,
         )
-        change_type = change_type.for_child(properties.change_type)
+        if properties.properties:
+            # Properties were defined in the before or after template, thus must play a role
+            # in affecting the change type of this resource.
+            change_type = change_type.for_child(properties.change_type)
         node_resource = NodeResource(
             scope=scope,
             change_type=change_type,

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_describer.py
@@ -82,10 +82,6 @@ class ChangeSetModelDescriber(ChangeSetModelPreproc):
         before_properties: Optional[PreprocProperties],
         after_properties: Optional[PreprocProperties],
     ) -> None:
-        # unchanged: nothing to do.
-        if before_properties == after_properties:
-            return
-
         action = cfn_api.ChangeAction.Modify
         if before_properties is None:
             action = cfn_api.ChangeAction.Add
@@ -111,6 +107,9 @@ class ChangeSetModelDescriber(ChangeSetModelPreproc):
     def _describe_resource_change(
         self, name: str, before: Optional[PreprocResource], after: Optional[PreprocResource]
     ) -> None:
+        if before == after:
+            # unchanged: nothing to do.
+            return
         if before is not None and after is not None:
             # Case: change on same type.
             if before.resource_type == after.resource_type:

--- a/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
+++ b/localstack-core/localstack/services/cloudformation/engine/v2/change_set_model_preproc.py
@@ -490,10 +490,6 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
             )
             condition_before = condition_delta.before
             condition_after = condition_delta.after
-            if not condition_before and condition_after:
-                change_type = ChangeType.CREATED
-            elif condition_before and not condition_after:
-                change_type = ChangeType.REMOVED
 
         type_delta = self.visit(node_resource.type_)
         properties_delta: PreprocEntityDelta[PreprocProperties, PreprocProperties] = self.visit(
@@ -502,14 +498,14 @@ class ChangeSetModelPreproc(ChangeSetModelVisitor):
 
         before = None
         after = None
-        if change_type != ChangeType.CREATED:
+        if change_type != ChangeType.CREATED and condition_before is None or condition_before:
             before = PreprocResource(
                 name=node_resource.name,
                 condition=condition_before,
                 resource_type=type_delta.before,
                 properties=properties_delta.before,
             )
-        if change_type != ChangeType.REMOVED:
+        if change_type != ChangeType.REMOVED and condition_after is None or condition_after:
             after = PreprocResource(
                 name=node_resource.name,
                 condition=condition_after,

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -444,9 +444,7 @@ class ResourceProviderExecutor:
         max_iterations = max(ceil(max_timeout / sleep_time), 2)
 
         for current_iteration in range(max_iterations):
-            resource_type = get_resource_type(
-                {"Type": raw_payload["resourceType"]}
-            )  # TODO: simplify signature of get_resource_type to just take the type
+            resource_type = raw_payload["resourceType"]
             resource["SpecifiedProperties"] = raw_payload["requestData"]["resourceProperties"]
 
             try:

--- a/localstack-core/localstack/services/cloudformation/stores.py
+++ b/localstack-core/localstack/services/cloudformation/stores.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from localstack.aws.api.cloudformation import StackStatus
 from localstack.services.cloudformation.engine.entities import Stack, StackChangeSet, StackSet
+from localstack.services.cloudformation.v2.entities import ChangeSet as ChangeSetV2
+from localstack.services.cloudformation.v2.entities import Stack as StackV2
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
 
 LOG = logging.getLogger(__name__)
@@ -11,6 +13,9 @@ LOG = logging.getLogger(__name__)
 class CloudFormationStore(BaseStore):
     # maps stack ID to stack details
     stacks: dict[str, Stack] = LocalAttribute(default=dict)
+    stacks_v2: dict[str, StackV2] = LocalAttribute(default=dict)
+
+    change_sets: dict[str, ChangeSetV2] = LocalAttribute(default=dict)
 
     # maps stack set ID to stack set details
     stack_sets: dict[str, StackSet] = LocalAttribute(default=dict)

--- a/localstack-core/localstack/services/cloudformation/v2/entities.py
+++ b/localstack-core/localstack/services/cloudformation/v2/entities.py
@@ -1,0 +1,201 @@
+from datetime import datetime, timezone
+from typing import TypedDict
+
+from localstack.aws.api.cloudformation import (
+    Changes,
+    ChangeSetStatus,
+    ChangeSetType,
+    CreateChangeSetInput,
+    DescribeChangeSetOutput,
+    ExecutionStatus,
+    Parameter,
+    StackDriftInformation,
+    StackDriftStatus,
+    StackStatus,
+    StackStatusReason,
+)
+from localstack.aws.api.cloudformation import (
+    Stack as ApiStack,
+)
+from localstack.services.cloudformation.engine.entities import (
+    StackIdentifier,
+    StackTemplate,
+)
+from localstack.services.cloudformation.engine.v2.change_set_model import (
+    ChangeSetModel,
+    NodeTemplate,
+)
+from localstack.services.cloudformation.engine.v2.change_set_model_describer import (
+    ChangeSetModelDescriber,
+)
+from localstack.utils.aws import arns
+from localstack.utils.strings import short_uid
+
+
+class ResolvedResource(TypedDict):
+    Properties: dict
+
+
+class Stack:
+    stack_name: str
+    parameters: list[Parameter]
+    change_set_name: str | None
+    status: StackStatus
+    status_reason: StackStatusReason | None
+    stack_id: str
+    creation_time: datetime
+
+    # state after deploy
+    resolved_parameters: dict[str, str]
+    resolved_resources: dict[str, ResolvedResource]
+
+    def __init__(
+        self,
+        account_id: str,
+        region_name: str,
+        request_payload: CreateChangeSetInput,
+        template: StackTemplate | None = None,
+        template_body: str | None = None,
+        change_set_ids: list[str] | None = None,
+    ):
+        self.account_id = account_id
+        self.region_name = region_name
+        self.template = template
+        self.template_body = template_body
+        self.status = StackStatus.CREATE_IN_PROGRESS
+        self.status_reason = None
+        self.change_set_ids = change_set_ids or []
+        self.creation_time = datetime.now(tz=timezone.utc)
+
+        self.stack_name = request_payload["StackName"]
+        self.change_set_name = request_payload.get("ChangeSetName")
+        self.parameters = request_payload.get("Parameters", [])
+        self.stack_id = arns.cloudformation_stack_arn(
+            self.stack_name,
+            stack_id=StackIdentifier(
+                account_id=self.account_id, region=self.region_name, stack_name=self.stack_name
+            ).generate(tags=request_payload.get("Tags")),
+            account_id=self.account_id,
+            region_name=self.region_name,
+        )
+
+        # TODO: only kept for v1 compatibility
+        self.request_payload = request_payload
+
+        # state after deploy
+        self.resolved_parameters = {}
+        self.resolved_resources = {}
+
+    def set_stack_status(self, status: StackStatus, reason: StackStatusReason | None = None):
+        self.status = status
+        if reason:
+            self.status_reason = reason
+
+    def describe_details(self) -> ApiStack:
+        return {
+            "CreationTime": self.creation_time,
+            "StackId": self.stack_id,
+            "StackName": self.stack_name,
+            "StackStatus": self.status,
+            "StackStatusReason": self.status_reason,
+            # fake values
+            "DisableRollback": False,
+            "DriftInformation": StackDriftInformation(
+                StackDriftStatus=StackDriftStatus.NOT_CHECKED
+            ),
+            "EnableTerminationProtection": False,
+            "LastUpdatedTime": self.creation_time,
+            "RollbackConfiguration": {},
+            "Tags": [],
+        }
+
+
+class ChangeSet:
+    change_set_name: str
+    change_set_id: str
+    change_set_type: ChangeSetType
+    update_graph: NodeTemplate | None
+    status: ChangeSetStatus
+    execution_status: ExecutionStatus
+    creation_time: datetime
+
+    def __init__(
+        self,
+        stack: Stack,
+        request_payload: CreateChangeSetInput,
+        template: StackTemplate | None = None,
+    ):
+        self.stack = stack
+        self.template = template
+        self.status = ChangeSetStatus.CREATE_IN_PROGRESS
+        self.execution_status = ExecutionStatus.AVAILABLE
+        self.update_graph = None
+        self.creation_time = datetime.now(tz=timezone.utc)
+
+        self.change_set_name = request_payload["ChangeSetName"]
+        self.change_set_type = request_payload.get("ChangeSetType", ChangeSetType.UPDATE)
+        self.change_set_id = arns.cloudformation_change_set_arn(
+            self.change_set_name,
+            change_set_id=short_uid(),
+            account_id=self.stack.account_id,
+            region_name=self.stack.region_name,
+        )
+
+    def set_change_set_status(self, status: ChangeSetStatus):
+        self.status = status
+
+    def set_execution_status(self, execution_status: ExecutionStatus):
+        self.execution_status = execution_status
+
+    @property
+    def account_id(self) -> str:
+        return self.stack.account_id
+
+    @property
+    def region_name(self) -> str:
+        return self.stack.region_name
+
+    def populate_update_graph(
+        self,
+        before_template: dict | None = None,
+        after_template: dict | None = None,
+        before_parameters: dict | None = None,
+        after_parameters: dict | None = None,
+    ) -> None:
+        change_set_model = ChangeSetModel(
+            before_template=before_template,
+            after_template=after_template,
+            before_parameters=before_parameters,
+            after_parameters=after_parameters,
+        )
+        self.update_graph = change_set_model.get_update_model()
+
+    def describe_details(self, include_property_values: bool) -> DescribeChangeSetOutput:
+        change_set_describer = ChangeSetModelDescriber(
+            node_template=self.update_graph,
+            include_property_values=include_property_values,
+        )
+        changes: Changes = change_set_describer.get_changes()
+
+        result = {
+            "Status": self.status,
+            "ChangeSetType": self.change_set_type,
+            "ChangeSetName": self.change_set_name,
+            "ExecutionStatus": self.execution_status,
+            "RollbackConfiguration": {},
+            "StackId": self.stack.stack_id,
+            "StackName": self.stack.stack_name,
+            "StackStatus": self.stack.status,
+            "CreationTime": self.creation_time,
+            "LastUpdatedTime": "",
+            "DisableRollback": "",
+            "EnableTerminationProtection": "",
+            "Transform": "",
+            # TODO: mask no echo
+            "Parameters": [
+                Parameter(ParameterKey=key, ParameterValue=value)
+                for (key, value) in self.stack.resolved_parameters.items()
+            ],
+            "Changes": changes,
+        }
+        return result

--- a/localstack-core/localstack/services/cloudformation/v2/provider.py
+++ b/localstack-core/localstack/services/cloudformation/v2/provider.py
@@ -1,18 +1,19 @@
-import json
 import logging
-from copy import deepcopy
 from typing import Any
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.cloudformation import (
-    Changes,
     ChangeSetNameOrId,
     ChangeSetNotFoundException,
+    ChangeSetStatus,
     ChangeSetType,
     ClientRequestToken,
     CreateChangeSetInput,
     CreateChangeSetOutput,
+    DeletionMode,
     DescribeChangeSetOutput,
+    DescribeStackEventsOutput,
+    DescribeStacksOutput,
     DisableRollback,
     ExecuteChangeSetOutput,
     ExecutionStatus,
@@ -21,22 +22,14 @@ from localstack.aws.api.cloudformation import (
     NextToken,
     Parameter,
     RetainExceptOnCreate,
+    RetainResources,
+    RoleARN,
+    StackName,
     StackNameOrId,
     StackStatus,
 )
 from localstack.services.cloudformation import api_utils
-from localstack.services.cloudformation.engine import parameters as param_resolver
-from localstack.services.cloudformation.engine import template_deployer, template_preparer
-from localstack.services.cloudformation.engine.entities import Stack, StackChangeSet
-from localstack.services.cloudformation.engine.parameters import mask_no_echo, strip_parameter_type
-from localstack.services.cloudformation.engine.resource_ordering import (
-    NoResourceInStack,
-    order_resources,
-)
-from localstack.services.cloudformation.engine.template_utils import resolve_stack_conditions
-from localstack.services.cloudformation.engine.v2.change_set_model_describer import (
-    ChangeSetModelDescriber,
-)
+from localstack.services.cloudformation.engine import template_preparer
 from localstack.services.cloudformation.engine.v2.change_set_model_executor import (
     ChangeSetModelExecutor,
 )
@@ -45,16 +38,58 @@ from localstack.services.cloudformation.provider import (
     ARN_CHANGESET_REGEX,
     ARN_STACK_REGEX,
     CloudformationProvider,
-    clone_stack_params,
 )
 from localstack.services.cloudformation.stores import (
-    find_change_set,
-    find_stack,
+    CloudFormationStore,
     get_cloudformation_store,
 )
-from localstack.utils.collections import remove_attributes
+from localstack.services.cloudformation.v2.entities import ChangeSet, Stack
+from localstack.utils.threads import start_worker_thread
 
 LOG = logging.getLogger(__name__)
+
+
+def is_stack_arn(stack_name_or_id: str) -> bool:
+    return ARN_STACK_REGEX.match(stack_name_or_id) is not None
+
+
+def is_changeset_arn(change_set_name_or_id: str) -> bool:
+    return ARN_CHANGESET_REGEX.match(change_set_name_or_id) is not None
+
+
+def find_change_set_v2(
+    state: CloudFormationStore, change_set_name: str, stack_name: str | None = None
+) -> ChangeSet | None:
+    change_set: ChangeSet | None = None
+    if is_changeset_arn(change_set_name):
+        change_set = state.change_sets[change_set_name]
+    else:
+        if stack_name is not None:
+            stack: Stack | None = None
+            if is_stack_arn(stack_name):
+                stack = state.stacks_v2[stack_name]
+            else:
+                for stack_candidate in state.stacks_v2.values():
+                    # TODO: check for active stacks
+                    if (
+                        stack_candidate.stack_name == stack_name
+                        and stack.status != StackStatus.DELETE_COMPLETE
+                    ):
+                        stack = stack_candidate
+                        break
+
+            if not stack:
+                raise NotImplementedError(f"no stack found for change set {change_set_name}")
+
+            for change_set_id in stack.change_set_ids:
+                change_set_candidate = state.change_sets[change_set_id]
+                if change_set_candidate.change_set_name == change_set_name:
+                    change_set = change_set_candidate
+                    break
+        else:
+            raise NotImplementedError
+
+    return change_set
 
 
 class CloudformationProviderV2(CloudformationProvider):
@@ -62,15 +97,23 @@ class CloudformationProviderV2(CloudformationProvider):
     def create_change_set(
         self, context: RequestContext, request: CreateChangeSetInput
     ) -> CreateChangeSetOutput:
+        try:
+            stack_name = request["StackName"]
+        except KeyError:
+            # TODO: proper exception
+            raise ValidationError("StackName must be specified")
+        try:
+            change_set_name = request["ChangeSetName"]
+        except KeyError:
+            # TODO: proper exception
+            raise ValidationError("StackName must be specified")
+
         state = get_cloudformation_store(context.account_id, context.region)
 
-        req_params = request
-        change_set_type = req_params.get("ChangeSetType", "UPDATE")
-        stack_name = req_params.get("StackName")
-        change_set_name = req_params.get("ChangeSetName")
-        template_body = req_params.get("TemplateBody")
+        change_set_type = request.get("ChangeSetType", "UPDATE")
+        template_body = request.get("TemplateBody")
         # s3 or secretsmanager url
-        template_url = req_params.get("TemplateURL")
+        template_url = request.get("TemplateURL")
 
         # validate and resolve template
         if template_body and template_url:
@@ -83,29 +126,19 @@ class CloudformationProviderV2(CloudformationProvider):
                 "Specify exactly one of 'TemplateBody' or 'TemplateUrl'"
             )  # TODO: check proper message
 
-        api_utils.prepare_template_body(
-            req_params
-        )  # TODO: function has too many unclear responsibilities
-        if not template_body:
-            template_body = req_params[
-                "TemplateBody"
-            ]  # should then have been set by prepare_template_body
-        template = template_preparer.parse_template(req_params["TemplateBody"])
-
-        del req_params["TemplateBody"]  # TODO: stop mutating req_params
-        template["StackName"] = stack_name
-        # TODO: validate with AWS what this is actually doing?
-        template["ChangeSetName"] = change_set_name
+        template_body = api_utils.extract_template_body(request)
+        structured_template = template_preparer.parse_template(template_body)
 
         # this is intentionally not in a util yet. Let's first see how the different operations deal with these before generalizing
         # handle ARN stack_name here (not valid for initial CREATE, since stack doesn't exist yet)
-        if ARN_STACK_REGEX.match(stack_name):
-            if not (stack := state.stacks.get(stack_name)):
+        if is_stack_arn(stack_name):
+            stack = state.stacks_v2.get(stack_name)
+            if not stack:
                 raise ValidationError(f"Stack '{stack_name}' does not exist.")
         else:
             # stack name specified, so fetch the stack by name
             stack_candidates: list[Stack] = [
-                s for stack_arn, s in state.stacks.items() if s.stack_name == stack_name
+                s for stack_arn, s in state.stacks_v2.items() if s.stack_name == stack_name
             ]
             active_stack_candidates = [
                 s for s in stack_candidates if self._stack_status_is_active(s.status)
@@ -113,22 +146,20 @@ class CloudformationProviderV2(CloudformationProvider):
 
             # on a CREATE an empty Stack should be generated if we didn't find an active one
             if not active_stack_candidates and change_set_type == ChangeSetType.CREATE:
-                empty_stack_template = dict(template)
-                empty_stack_template["Resources"] = {}
-                req_params_copy = clone_stack_params(req_params)
                 stack = Stack(
                     context.account_id,
                     context.region,
-                    req_params_copy,
-                    empty_stack_template,
+                    request,
+                    structured_template,
                     template_body=template_body,
                 )
-                state.stacks[stack.stack_id] = stack
-                stack.set_stack_status("REVIEW_IN_PROGRESS")
+                state.stacks_v2[stack.stack_id] = stack
             else:
                 if not active_stack_candidates:
                     raise ValidationError(f"Stack '{stack_name}' does not exist.")
                 stack = active_stack_candidates[0]
+
+        stack.set_stack_status(StackStatus.REVIEW_IN_PROGRESS)
 
         # TODO: test if rollback status is allowed as well
         if (
@@ -139,14 +170,15 @@ class CloudformationProviderV2(CloudformationProvider):
                 f"Stack [{stack_name}] already exists and cannot be created again with the changeSet [{change_set_name}]."
             )
 
-        old_parameters: dict[str, Parameter] = {}
+        before_parameters: dict[str, Parameter] | None = None
         match change_set_type:
             case ChangeSetType.UPDATE:
+                before_parameters = stack.resolved_parameters
                 # add changeset to existing stack
-                old_parameters = {
-                    k: mask_no_echo(strip_parameter_type(v))
-                    for k, v in stack.resolved_parameters.items()
-                }
+                # old_parameters = {
+                #     k: mask_no_echo(strip_parameter_type(v))
+                #     for k, v in stack.resolved_parameters.items()
+                # }
             case ChangeSetType.IMPORT:
                 raise NotImplementedError()  # TODO: implement importing resources
             case ChangeSetType.CREATE:
@@ -158,51 +190,17 @@ class CloudformationProviderV2(CloudformationProvider):
                 )
                 raise ValidationError(msg)
 
-        # resolve parameters
-        new_parameters: dict[str, Parameter] = param_resolver.convert_stack_parameters_to_dict(
-            request.get("Parameters")
-        )
-        parameter_declarations = param_resolver.extract_stack_parameter_declarations(template)
-        resolved_parameters = param_resolver.resolve_parameters(
-            account_id=context.account_id,
-            region_name=context.region,
-            parameter_declarations=parameter_declarations,
-            new_parameters=new_parameters,
-            old_parameters=old_parameters,
-        )
-
-        # TODO: remove this when fixing Stack.resources and transformation order
-        #   currently we need to create a stack with existing resources + parameters so that resolve refs recursively in here will work.
-        #   The correct way to do it would be at a later stage anyway just like a normal intrinsic function
-        req_params_copy = clone_stack_params(req_params)
-        temp_stack = Stack(context.account_id, context.region, req_params_copy, template)
-        temp_stack.set_resolved_parameters(resolved_parameters)
-
-        # TODO: everything below should be async
-        # apply template transformations
-        transformed_template = template_preparer.transform_template(
-            context.account_id,
-            context.region,
-            template,
-            stack_name=temp_stack.stack_name,
-            resources=temp_stack.resources,
-            mappings=temp_stack.mappings,
-            conditions={},  # TODO: we don't have any resolved conditions yet at this point but we need the conditions because of the samtranslator...
-            resolved_parameters=resolved_parameters,
-        )
+        # TDOO: transformations
 
         # TODO: reconsider the way parameters are modelled in the update graph process.
         #  The options might be reduce to using the current style, or passing the extra information
         #  as a metadata object. The choice should be made considering when the extra information
         #  is needed for the update graph building, or only looked up in downstream tasks (metadata).
         request_parameters = request.get("Parameters", list())
+        # TODO: handle parameter defaults and resolution
         after_parameters: dict[str, Any] = {
             parameter["ParameterKey"]: parameter["ParameterValue"]
             for parameter in request_parameters
-        }
-        before_parameters: dict[str, Any] = {
-            parameter["ParameterKey"]: parameter["ParameterValue"]
-            for parameter in old_parameters.values()
         }
 
         # TODO: update this logic to always pass the clean template object if one exists. The
@@ -210,78 +208,24 @@ class CloudformationProviderV2(CloudformationProvider):
         #  its parameters and conditions populated.
         before_template = None
         if change_set_type == ChangeSetType.UPDATE:
-            before_template = json.loads(
-                stack.template_body
-            )  # template_original is sometimes invalid
-        after_template = template
+            before_template = stack.template
+        after_template = structured_template
 
         # create change set for the stack and apply changes
-        change_set = StackChangeSet(
-            context.account_id,
-            context.region,
-            stack,
-            req_params,
-            transformed_template,
-            change_set_type=change_set_type,
-        )
+        change_set = ChangeSet(stack, request)
+
         # only set parameters for the changeset, then switch to stack on execute_change_set
-        change_set.template_body = template_body
         change_set.populate_update_graph(
             before_template=before_template,
             after_template=after_template,
             before_parameters=before_parameters,
             after_parameters=after_parameters,
         )
+        change_set.set_change_set_status(ChangeSetStatus.CREATE_COMPLETE)
+        stack.change_set_id = change_set.change_set_id
+        state.change_sets[change_set.change_set_id] = change_set
 
-        # TODO: move this logic of condition resolution with metadata to the ChangeSetModelPreproc or Executor
-        raw_conditions = transformed_template.get("Conditions", {})
-        resolved_stack_conditions = resolve_stack_conditions(
-            account_id=context.account_id,
-            region_name=context.region,
-            conditions=raw_conditions,
-            parameters=resolved_parameters,
-            mappings=temp_stack.mappings,
-            stack_name=stack_name,
-        )
-        change_set.set_resolved_stack_conditions(resolved_stack_conditions)
-        change_set.set_resolved_parameters(resolved_parameters)
-
-        # a bit gross but use the template ordering to validate missing resources
-        try:
-            order_resources(
-                transformed_template["Resources"],
-                resolved_parameters=resolved_parameters,
-                resolved_conditions=resolved_stack_conditions,
-            )
-        except NoResourceInStack as e:
-            raise ValidationError(str(e)) from e
-
-        deployer = template_deployer.TemplateDeployer(
-            context.account_id, context.region, change_set
-        )
-        changes = deployer.construct_changes(
-            stack,
-            change_set,
-            change_set_id=change_set.change_set_id,
-            append_to_changeset=True,
-            filter_unchanged_resources=True,
-        )
-        stack.change_sets.append(change_set)
-        if not changes:
-            change_set.metadata["Status"] = "FAILED"
-            change_set.metadata["ExecutionStatus"] = "UNAVAILABLE"
-            change_set.metadata["StatusReason"] = (
-                "The submitted information didn't contain changes. Submit different information to create a change set."
-            )
-        else:
-            change_set.metadata["Status"] = (
-                "CREATE_COMPLETE"  # technically for some time this should first be CREATE_PENDING
-            )
-            change_set.metadata["ExecutionStatus"] = (
-                "AVAILABLE"  # technically for some time this should first be UNAVAILABLE
-            )
-
-        return CreateChangeSetOutput(StackId=change_set.stack_id, Id=change_set.change_set_id)
+        return CreateChangeSetOutput(StackId=stack.stack_id, Id=change_set.change_set_id)
 
     @handler("ExecuteChangeSet")
     def execute_change_set(
@@ -294,40 +238,49 @@ class CloudformationProviderV2(CloudformationProvider):
         retain_except_on_create: RetainExceptOnCreate | None = None,
         **kwargs,
     ) -> ExecuteChangeSetOutput:
-        change_set = find_change_set(
-            context.account_id,
-            context.region,
-            change_set_name,
-            stack_name=stack_name,
-            active_only=True,
-        )
+        state = get_cloudformation_store(context.account_id, context.region)
+
+        change_set = find_change_set_v2(state, change_set_name, stack_name)
         if not change_set:
             raise ChangeSetNotFoundException(f"ChangeSet [{change_set_name}] does not exist")
-        if change_set.metadata.get("ExecutionStatus") != ExecutionStatus.AVAILABLE:
+
+        if change_set.execution_status != ExecutionStatus.AVAILABLE:
             LOG.debug("Change set %s not in execution status 'AVAILABLE'", change_set_name)
             raise InvalidChangeSetStatusException(
-                f"ChangeSet [{change_set.metadata['ChangeSetId']}] cannot be executed in its current status of [{change_set.metadata.get('Status')}]"
+                f"ChangeSet [{change_set.change_set_id}] cannot be executed in its current status of [{change_set.status}]"
             )
-        stack_name = change_set.stack.stack_name
-        LOG.debug(
-            'Executing change set "%s" for stack "%s" with %s resources ...',
-            change_set_name,
-            stack_name,
-            len(change_set.template_resources),
-        )
+        # LOG.debug(
+        #     'Executing change set "%s" for stack "%s" with %s resources ...',
+        #     change_set_name,
+        #     stack_name,
+        #     len(change_set.template_resources),
+        # )
         if not change_set.update_graph:
             raise RuntimeError("Programming error: no update graph found for change set")
 
-        change_set_executor = ChangeSetModelExecutor(
-            change_set.update_graph,
-            account_id=context.account_id,
-            region=context.region,
-            stack_name=change_set.stack.stack_name,
-            stack_id=change_set.stack.stack_id,
+        change_set.set_execution_status(ExecutionStatus.EXECUTE_IN_PROGRESS)
+        change_set.stack.set_stack_status(
+            StackStatus.UPDATE_IN_PROGRESS
+            if change_set.change_set_type == ChangeSetType.UPDATE
+            else StackStatus.CREATE_IN_PROGRESS
         )
-        new_resources = change_set_executor.execute()
-        change_set.stack.set_stack_status(f"{change_set.change_set_type or 'UPDATE'}_COMPLETE")
-        change_set.stack.resources = new_resources
+
+        change_set_executor = ChangeSetModelExecutor(
+            change_set,
+        )
+
+        def _run(*args):
+            new_resources, new_parameters = change_set_executor.execute()
+            new_stack_status = StackStatus.UPDATE_COMPLETE
+            if change_set.change_set_type == ChangeSetType.CREATE:
+                new_stack_status = StackStatus.CREATE_COMPLETE
+            change_set.stack.set_stack_status(new_stack_status)
+            change_set.set_execution_status(ExecutionStatus.EXECUTE_COMPLETE)
+            change_set.stack.resolved_resources = new_resources
+            change_set.stack.resolved_parameters = new_parameters
+
+        start_worker_thread(_run)
+
         return ExecuteChangeSetOutput()
 
     @handler("DescribeChangeSet")
@@ -342,40 +295,92 @@ class CloudformationProviderV2(CloudformationProvider):
     ) -> DescribeChangeSetOutput:
         # TODO add support for include_property_values
         # only relevant if change_set_name isn't an ARN
-        if not ARN_CHANGESET_REGEX.match(change_set_name):
-            if not stack_name:
-                raise ValidationError(
-                    "StackName must be specified if ChangeSetName is not specified as an ARN."
-                )
-
-            stack = find_stack(context.account_id, context.region, stack_name)
-            if not stack:
-                raise ValidationError(f"Stack [{stack_name}] does not exist")
-
-        change_set = find_change_set(
-            context.account_id, context.region, change_set_name, stack_name=stack_name
-        )
+        state = get_cloudformation_store(context.account_id, context.region)
+        change_set = find_change_set_v2(state, change_set_name, stack_name)
         if not change_set:
             raise ChangeSetNotFoundException(f"ChangeSet [{change_set_name}] does not exist")
 
-        change_set_describer = ChangeSetModelDescriber(
-            node_template=change_set.update_graph,
-            include_property_values=bool(include_property_values),
+        result = change_set.describe_details(
+            include_property_values=include_property_values or False
         )
-        changes: Changes = change_set_describer.get_changes()
-
-        attrs = [
-            "ChangeSetType",
-            "StackStatus",
-            "LastUpdatedTime",
-            "DisableRollback",
-            "EnableTerminationProtection",
-            "Transform",
-        ]
-        result = remove_attributes(deepcopy(change_set.metadata), attrs)
-        # TODO: replace this patch with a better solution
-        result["Parameters"] = [
-            mask_no_echo(strip_parameter_type(p)) for p in result.get("Parameters", [])
-        ]
-        result["Changes"] = changes
         return result
+
+    @handler("DescribeStacks")
+    def describe_stacks(
+        self,
+        context: RequestContext,
+        stack_name: StackName = None,
+        next_token: NextToken = None,
+        **kwargs,
+    ) -> DescribeStacksOutput:
+        state = get_cloudformation_store(context.account_id, context.region)
+        if stack_name:
+            if is_stack_arn(stack_name):
+                stack = state.stacks_v2[stack_name]
+            else:
+                stack_candidates = []
+                for stack in state.stacks_v2.values():
+                    if (
+                        stack.stack_name == stack_name
+                        and stack.status != StackStatus.DELETE_COMPLETE
+                    ):
+                        stack_candidates.append(stack)
+                if len(stack_candidates) == 0:
+                    raise ValidationError(f"No stack with name {stack_name} found")
+                elif len(stack_candidates) > 1:
+                    raise RuntimeError("Programing error, duplicate stacks found")
+                else:
+                    stack = stack_candidates[0]
+        else:
+            raise NotImplementedError
+
+        return DescribeStacksOutput(Stacks=[stack.describe_details()])
+
+    @handler("DescribeStackEvents")
+    def describe_stack_events(
+        self,
+        context: RequestContext,
+        stack_name: StackName = None,
+        next_token: NextToken = None,
+        **kwargs,
+    ) -> DescribeStackEventsOutput:
+        return DescribeStackEventsOutput(StackEvents=[])
+
+    @handler("DeleteStack")
+    def delete_stack(
+        self,
+        context: RequestContext,
+        stack_name: StackName,
+        retain_resources: RetainResources = None,
+        role_arn: RoleARN = None,
+        client_request_token: ClientRequestToken = None,
+        deletion_mode: DeletionMode = None,
+        **kwargs,
+    ) -> None:
+        state = get_cloudformation_store(context.account_id, context.region)
+        if stack_name:
+            if is_stack_arn(stack_name):
+                stack = state.stacks_v2[stack_name]
+            else:
+                stack_candidates = []
+                for stack in state.stacks_v2.values():
+                    if (
+                        stack.stack_name == stack_name
+                        and stack.status != StackStatus.DELETE_COMPLETE
+                    ):
+                        stack_candidates.append(stack)
+                if len(stack_candidates) == 0:
+                    raise ValidationError(f"No stack with name {stack_name} found")
+                elif len(stack_candidates) > 1:
+                    raise RuntimeError("Programing error, duplicate stacks found")
+                else:
+                    stack = stack_candidates[0]
+        else:
+            raise NotImplementedError
+
+        if not stack:
+            # aws will silently ignore invalid stack names - we should do the same
+            return
+
+        # TODO: actually delete
+        stack.set_stack_status(StackStatus.DELETE_COMPLETE)

--- a/localstack-core/localstack/services/sqs/provider.py
+++ b/localstack-core/localstack/services/sqs/provider.py
@@ -102,7 +102,6 @@ from localstack.services.sqs.utils import (
     is_fifo_queue,
     is_message_deduplication_id_required,
     parse_queue_url,
-    token_generator,
 )
 from localstack.services.stores import AccountRegionBundle
 from localstack.utils.aws.arns import parse_arn
@@ -116,7 +115,7 @@ from localstack.utils.cloudwatch.cloudwatch_util import (
 from localstack.utils.collections import PaginatedList
 from localstack.utils.run import FuncThread
 from localstack.utils.scheduler import Scheduler
-from localstack.utils.strings import md5
+from localstack.utils.strings import md5, token_generator
 from localstack.utils.threads import start_thread
 from localstack.utils.time import now
 

--- a/localstack-core/localstack/services/sqs/utils.py
+++ b/localstack-core/localstack/services/sqs/utils.py
@@ -184,9 +184,3 @@ def global_message_sequence():
 
 def generate_message_id():
     return long_uid()
-
-
-def token_generator(item: str) -> str:
-    base64_bytes = base64.b64encode(item.encode("utf-8"))
-    next_token = base64_bytes.decode("utf-8")
-    return next_token

--- a/localstack-core/localstack/services/ssm/resource_providers/aws_ssm_parameter.py
+++ b/localstack-core/localstack/services/ssm/resource_providers/aws_ssm_parameter.py
@@ -173,7 +173,8 @@ class SSMParameterProvider(ResourceProvider[SSMParameterProperties]):
 
         # tag handling
         new_tags = update_config_props.pop("Tags", {})
-        self.update_tags(ssm, model, new_tags)
+        if new_tags:
+            self.update_tags(ssm, model, new_tags)
 
         ssm.put_parameter(Overwrite=True, Tags=[], **update_config_props)
 

--- a/localstack-core/localstack/services/stepfunctions/backend/alias.py
+++ b/localstack-core/localstack/services/stepfunctions/backend/alias.py
@@ -11,9 +11,11 @@ from localstack.aws.api.stepfunctions import (
     Arn,
     CharacterRestrictedName,
     DescribeStateMachineAliasOutput,
+    PageToken,
     RoutingConfigurationList,
     StateMachineAliasListItem,
 )
+from localstack.utils.strings import token_generator
 
 
 class Alias:
@@ -25,6 +27,7 @@ class Alias:
     _state_machine_version_arns: list[Arn]
     _execution_probability_distribution: list[int]
     state_machine_alias_arn: Final[Arn]
+    tokenized_state_machine_alias_arn: Final[PageToken]
     create_date: datetime.datetime
 
     def __init__(
@@ -39,6 +42,7 @@ class Alias:
         self.name = name
         self._description = None
         self.state_machine_alias_arn = f"{state_machine_arn}:{name}"
+        self.tokenized_state_machine_alias_arn = token_generator(self.state_machine_alias_arn)
         self.update(description=description, routing_configuration_list=routing_configuration_list)
         self.create_date = self._get_mutex_date()
 

--- a/localstack-core/localstack/services/stepfunctions/stepfunctions_utils.py
+++ b/localstack-core/localstack/services/stepfunctions/stepfunctions_utils.py
@@ -46,7 +46,7 @@ def assert_pagination_parameters_valid(
     next_token: str,
     next_token_length_limit: int = 1024,
     max_results_upper_limit: int = 1000,
-) -> tuple[int, str]:
+) -> None:
     validation_errors = []
 
     match max_results:

--- a/localstack-core/localstack/services/sts/models.py
+++ b/localstack-core/localstack/services/sts/models.py
@@ -1,9 +1,19 @@
+from typing import TypedDict
+
+from localstack.aws.api.sts import Tag
 from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
 
 
+class SessionTaggingConfig(TypedDict):
+    # <lower-case-tag-key> => {"Key": <case-preserved-tag-key>, "Value": <tag-value>}
+    tags: dict[str, Tag]
+    # list of lowercase transitive tag keys
+    transitive_tags: list[str]
+
+
 class STSStore(BaseStore):
-    # maps access key ids to tags for the session they belong to
-    session_tags: dict[str, dict[str, str]] = CrossRegionAttribute(default=dict)
+    # maps access key ids to tagging config for the session they belong to
+    session_tags: dict[str, SessionTaggingConfig] = CrossRegionAttribute(default=dict)
 
 
 sts_stores = AccountRegionBundle("sts", STSStore)

--- a/localstack-core/localstack/services/sts/provider.py
+++ b/localstack-core/localstack/services/sts/provider.py
@@ -1,6 +1,6 @@
 import logging
 
-from localstack.aws.api import RequestContext
+from localstack.aws.api import RequestContext, ServiceException
 from localstack.aws.api.sts import (
     AssumeRoleResponse,
     GetCallerIdentityResponse,
@@ -21,10 +21,17 @@ from localstack.aws.api.sts import (
 from localstack.services.iam.iam_patches import apply_iam_patches
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.services.sts.models import sts_stores
+from localstack.services.sts.models import SessionTaggingConfig, sts_stores
 from localstack.utils.aws.arns import extract_account_id_from_arn
+from localstack.utils.aws.request_context import extract_access_key_id_from_auth_header
 
 LOG = logging.getLogger(__name__)
+
+
+class InvalidParameterValueError(ServiceException):
+    code = "InvalidParameterValue"
+    status_code = 400
+    sender_fault = True
 
 
 class StsProvider(StsApi, ServiceLifecycleHook):
@@ -54,15 +61,47 @@ class StsProvider(StsApi, ServiceLifecycleHook):
         provided_contexts: ProvidedContextsListType = None,
         **kwargs,
     ) -> AssumeRoleResponse:
-        response: AssumeRoleResponse = call_moto(context)
+        target_account_id = extract_account_id_from_arn(role_arn)
+        access_key_id = extract_access_key_id_from_auth_header(context.request.headers)
+        store = sts_stores[target_account_id]["us-east-1"]
+        existing_tagging_config = store.session_tags.get(access_key_id, {})
 
         if tags:
-            transformed_tags = {tag["Key"]: tag["Value"] for tag in tags}
-            # we should save it in the store of the role account, not the requester
-            account_id = extract_account_id_from_arn(role_arn)
-            # the region is hardcoded to "us-east-1" as IAM/STS are global services
-            # this will only differ for other partitions, which are not yet supported
-            store = sts_stores[account_id]["us-east-1"]
+            tag_keys = {tag["Key"].lower() for tag in tags}
+            # if the lower-cased set is smaller than the number of keys, there have to be some duplicates.
+            if len(tag_keys) < len(tags):
+                raise InvalidParameterValueError(
+                    "Duplicate tag keys found. Please note that Tag keys are case insensitive."
+                )
+
+            # prevent transitive tags from being overridden
+            if existing_tagging_config:
+                if set(existing_tagging_config["transitive_tags"]).intersection(tag_keys):
+                    raise InvalidParameterValueError(
+                        "One of the specified transitive tag keys can't be set because it conflicts with a transitive tag key from the calling session."
+                    )
+            if transitive_tag_keys:
+                transitive_tag_key_set = {key.lower() for key in transitive_tag_keys}
+                if not transitive_tag_key_set <= tag_keys:
+                    raise InvalidParameterValueError(
+                        "The specified transitive tag key must be included in the requested tags."
+                    )
+
+        response: AssumeRoleResponse = call_moto(context)
+
+        transitive_tag_keys = transitive_tag_keys or []
+        tags = tags or []
+        transformed_tags = {tag["Key"].lower(): tag for tag in tags}
+        # propagate transitive tags
+        if existing_tagging_config:
+            for tag in existing_tagging_config["transitive_tags"]:
+                transformed_tags[tag] = existing_tagging_config["tags"][tag]
+            transitive_tag_keys += existing_tagging_config["transitive_tags"]
+        if transformed_tags:
+            # store session tagging config
             access_key_id = response["Credentials"]["AccessKeyId"]
-            store.session_tags[access_key_id] = transformed_tags
+            store.session_tags[access_key_id] = SessionTaggingConfig(
+                tags=transformed_tags,
+                transitive_tags=[key.lower() for key in transitive_tag_keys],
+            )
         return response

--- a/localstack-core/localstack/testing/pytest/fixtures.py
+++ b/localstack-core/localstack/testing/pytest/fixtures.py
@@ -1974,6 +1974,30 @@ def ses_verify_identity(aws_client):
 
 
 @pytest.fixture
+def setup_sender_email_address(ses_verify_identity):
+    """
+    If the test is running against AWS then assume the email address passed is already
+    verified, and passes the given email address through. Otherwise, it generates one random
+    email address and verify them.
+    """
+
+    def inner(sender_email_address: Optional[str] = None) -> str:
+        if is_aws_cloud():
+            if sender_email_address is None:
+                raise ValueError(
+                    "sender_email_address must be specified to run this test against AWS"
+                )
+        else:
+            # overwrite the given parameters with localstack specific ones
+            sender_email_address = f"sender-{short_uid()}@example.com"
+            ses_verify_identity(sender_email_address)
+
+        return sender_email_address
+
+    return inner
+
+
+@pytest.fixture
 def ec2_create_security_group(aws_client):
     ec2_sgs = []
 

--- a/localstack-core/localstack/utils/aws/arns.py
+++ b/localstack-core/localstack/utils/aws/arns.py
@@ -525,6 +525,16 @@ def route53_resolver_query_log_config_arn(id: str, account_id: str, region_name:
 
 
 #
+# SES
+#
+
+
+def ses_identity_arn(email: str, account_id: str, region_name: str) -> str:
+    pattern = "arn:%s:ses:%s:%s:identity/%s"
+    return _resource_arn(email, pattern, account_id=account_id, region_name=region_name)
+
+
+#
 # Other ARN related helpers
 #
 

--- a/localstack-core/localstack/utils/strings.py
+++ b/localstack-core/localstack/utils/strings.py
@@ -238,3 +238,9 @@ def key_value_pairs_to_dict(pairs: str, delimiter: str = ",", separator: str = "
     """
     splits = [split_pair.partition(separator) for split_pair in pairs.split(delimiter)]
     return {key.strip(): value.strip() for key, _, value in splits}
+
+
+def token_generator(item: str) -> str:
+    base64_bytes = base64.b64encode(item.encode("utf-8"))
+    token = base64_bytes.decode("utf-8")
+    return token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ runtime = [
     "json5>=0.9.11",
     "jsonpath-ng>=1.6.1",
     "jsonpath-rw>=1.4.0",
-    "moto-ext[all]==5.1.1.post2",
+    "moto-ext[all]==5.1.3.post1",
     "opensearch-py>=2.4.1",
     "pymongo>=4.2.0",
     "pyopenssl>=23.0.0",

--- a/requirements-base-runtime.txt
+++ b/requirements-base-runtime.txt
@@ -9,7 +9,7 @@ attrs==25.3.0
     #   jsonschema
     #   localstack-twisted
     #   referencing
-awscrt==0.25.7
+awscrt==0.26.1
     # via localstack-core (pyproject.toml)
 boto3==1.37.28
     # via localstack-core (pyproject.toml)
@@ -180,13 +180,13 @@ six==1.17.0
     #   rfc3339-validator
 tailer==0.4.1
     # via localstack-core (pyproject.toml)
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   localstack-twisted
     #   pyopenssl
     #   readerwriterlock
     #   referencing
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   botocore
     #   docker

--- a/requirements-basic.txt
+++ b/requirements-basic.txt
@@ -54,5 +54,5 @@ semver==3.0.4
     # via localstack-core (pyproject.toml)
 tailer==0.4.1
     # via localstack-core (pyproject.toml)
-urllib3==2.3.0
+urllib3==2.4.0
     # via requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -250,7 +250,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.1.1.post2
+moto-ext==5.1.3.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,15 +27,15 @@ attrs==25.3.0
     #   jsonschema
     #   localstack-twisted
     #   referencing
-aws-cdk-asset-awscli-v1==2.2.231
+aws-cdk-asset-awscli-v1==2.2.232
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
 aws-cdk-cloud-assembly-schema==41.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.188.0
+aws-cdk-lib==2.189.1
     # via localstack-core
-aws-sam-translator==1.96.0
+aws-sam-translator==1.97.0
     # via
     #   cfn-lint
     #   localstack-core
@@ -43,7 +43,7 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.38.28
     # via localstack-core
-awscrt==0.25.7
+awscrt==0.26.1
     # via localstack-core
 boto3==1.37.28
     # via
@@ -82,7 +82,7 @@ cffi==1.17.1
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==1.32.4
+cfn-lint==1.33.2
     # via moto-ext
 charset-normalizer==3.4.1
     # via requests
@@ -102,7 +102,7 @@ coverage==7.8.0
     #   localstack-core
 coveralls==4.0.1
     # via localstack-core (pyproject.toml)
-crontab==1.0.1
+crontab==1.0.4
     # via localstack-core
 cryptography==44.0.2
     # via
@@ -160,7 +160,7 @@ h2==4.2.0
     #   localstack-twisted
 hpack==4.1.0
     # via h2
-httpcore==1.0.7
+httpcore==1.0.8
     # via httpx
 httpx==0.28.1
     # via localstack-core
@@ -275,7 +275,7 @@ openapi-spec-validator==0.7.1
     #   openapi-core
 opensearch-py==2.8.0
     # via localstack-core
-orderly-set==5.3.1
+orderly-set==5.4.0
     # via deepdiff
 packaging==24.2
     # via
@@ -331,13 +331,13 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.22
     # via cffi
-pydantic==2.11.2
+pydantic==2.11.3
     # via aws-sam-translator
 pydantic-core==2.33.1
     # via pydantic
 pygments==2.19.1
     # via rich
-pymongo==4.11.3
+pymongo==4.12.0
     # via localstack-core
 pyopenssl==25.0.0
     # via
@@ -355,7 +355,7 @@ pytest==8.3.5
     #   pytest-rerunfailures
     #   pytest-split
     #   pytest-tinybird
-pytest-httpserver==1.1.2
+pytest-httpserver==1.1.3
     # via localstack-core
 pytest-rerunfailures==15.0
     # via localstack-core
@@ -425,7 +425,7 @@ rsa==4.7.2
     # via awscli
 rstr==3.2.2
     # via localstack-core (pyproject.toml)
-ruff==0.11.4
+ruff==0.11.5
     # via localstack-core (pyproject.toml)
 s3transfer==0.11.4
     # via
@@ -457,7 +457,7 @@ typeguard==2.13.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   anyio
     #   aws-sam-translator
@@ -472,7 +472,7 @@ typing-extensions==4.13.1
     #   typing-inspection
 typing-inspection==0.4.0
     # via pydantic
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   botocore
     #   docker

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -188,7 +188,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.1.1.post2
+moto-ext==5.1.3.post1
     # via localstack-core (pyproject.toml)
 mpmath==1.3.0
     # via sympy

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   jsonschema
     #   localstack-twisted
     #   referencing
-aws-sam-translator==1.96.0
+aws-sam-translator==1.97.0
     # via
     #   cfn-lint
     #   localstack-core (pyproject.toml)
@@ -31,7 +31,7 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.38.28
     # via localstack-core (pyproject.toml)
-awscrt==0.25.7
+awscrt==0.26.1
     # via localstack-core
 boto3==1.37.28
     # via
@@ -64,7 +64,7 @@ certifi==2025.1.31
     #   requests
 cffi==1.17.1
     # via cryptography
-cfn-lint==1.32.4
+cfn-lint==1.33.2
     # via moto-ext
 charset-normalizer==3.4.1
     # via requests
@@ -76,7 +76,7 @@ colorama==0.4.6
     # via awscli
 constantly==23.10.4
     # via localstack-twisted
-crontab==1.0.1
+crontab==1.0.4
     # via localstack-core (pyproject.toml)
 cryptography==44.0.2
     # via
@@ -239,13 +239,13 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.22
     # via cffi
-pydantic==2.11.2
+pydantic==2.11.3
     # via aws-sam-translator
 pydantic-core==2.33.1
     # via pydantic
 pygments==2.19.1
     # via rich
-pymongo==4.11.3
+pymongo==4.12.0
     # via localstack-core (pyproject.toml)
 pyopenssl==25.0.0
     # via
@@ -332,7 +332,7 @@ tailer==0.4.1
     # via
     #   localstack-core
     #   localstack-core (pyproject.toml)
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   aws-sam-translator
     #   cfn-lint
@@ -345,7 +345,7 @@ typing-extensions==4.13.1
     #   typing-inspection
 typing-inspection==0.4.0
     # via pydantic
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   botocore
     #   docker

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -27,15 +27,15 @@ attrs==25.3.0
     #   jsonschema
     #   localstack-twisted
     #   referencing
-aws-cdk-asset-awscli-v1==2.2.231
+aws-cdk-asset-awscli-v1==2.2.232
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
 aws-cdk-cloud-assembly-schema==41.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.188.0
+aws-cdk-lib==2.189.1
     # via localstack-core (pyproject.toml)
-aws-sam-translator==1.96.0
+aws-sam-translator==1.97.0
     # via
     #   cfn-lint
     #   localstack-core
@@ -43,7 +43,7 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.38.28
     # via localstack-core
-awscrt==0.25.7
+awscrt==0.26.1
     # via localstack-core
 boto3==1.37.28
     # via
@@ -80,7 +80,7 @@ certifi==2025.1.31
     #   requests
 cffi==1.17.1
     # via cryptography
-cfn-lint==1.32.4
+cfn-lint==1.33.2
     # via moto-ext
 charset-normalizer==3.4.1
     # via requests
@@ -96,7 +96,7 @@ constructs==10.4.2
     # via aws-cdk-lib
 coverage==7.8.0
     # via localstack-core (pyproject.toml)
-crontab==1.0.1
+crontab==1.0.4
     # via localstack-core
 cryptography==44.0.2
     # via
@@ -146,7 +146,7 @@ h2==4.2.0
     #   localstack-twisted
 hpack==4.1.0
     # via h2
-httpcore==1.0.7
+httpcore==1.0.8
     # via httpx
 httpx==0.28.1
     # via localstack-core (pyproject.toml)
@@ -254,7 +254,7 @@ openapi-spec-validator==0.7.1
     #   openapi-core
 opensearch-py==2.8.0
     # via localstack-core
-orderly-set==5.3.1
+orderly-set==5.4.0
     # via deepdiff
 packaging==24.2
     # via
@@ -301,13 +301,13 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.22
     # via cffi
-pydantic==2.11.2
+pydantic==2.11.3
     # via aws-sam-translator
 pydantic-core==2.33.1
     # via pydantic
 pygments==2.19.1
     # via rich
-pymongo==4.11.3
+pymongo==4.12.0
     # via localstack-core
 pyopenssl==25.0.0
     # via
@@ -323,7 +323,7 @@ pytest==8.3.5
     #   pytest-rerunfailures
     #   pytest-split
     #   pytest-tinybird
-pytest-httpserver==1.1.2
+pytest-httpserver==1.1.3
     # via localstack-core (pyproject.toml)
 pytest-rerunfailures==15.0
     # via localstack-core (pyproject.toml)
@@ -419,7 +419,7 @@ typeguard==2.13.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   anyio
     #   aws-sam-translator
@@ -434,7 +434,7 @@ typing-extensions==4.13.1
     #   typing-inspection
 typing-inspection==0.4.0
     # via pydantic
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   botocore
     #   docker

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -234,7 +234,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.1.1.post2
+moto-ext==5.1.3.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -27,15 +27,15 @@ attrs==25.3.0
     #   jsonschema
     #   localstack-twisted
     #   referencing
-aws-cdk-asset-awscli-v1==2.2.231
+aws-cdk-asset-awscli-v1==2.2.232
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.1.0
     # via aws-cdk-lib
 aws-cdk-cloud-assembly-schema==41.2.0
     # via aws-cdk-lib
-aws-cdk-lib==2.188.0
+aws-cdk-lib==2.189.1
     # via localstack-core
-aws-sam-translator==1.96.0
+aws-sam-translator==1.97.0
     # via
     #   cfn-lint
     #   localstack-core
@@ -43,7 +43,7 @@ aws-xray-sdk==2.14.0
     # via moto-ext
 awscli==1.38.28
     # via localstack-core
-awscrt==0.25.7
+awscrt==0.26.1
     # via localstack-core
 boto3==1.37.28
     # via
@@ -51,7 +51,7 @@ boto3==1.37.28
     #   aws-sam-translator
     #   localstack-core
     #   moto-ext
-boto3-stubs==1.37.29
+boto3-stubs==1.37.34
     # via localstack-core (pyproject.toml)
 botocore==1.37.28
     # via
@@ -86,7 +86,7 @@ cffi==1.17.1
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
-cfn-lint==1.32.4
+cfn-lint==1.33.2
     # via moto-ext
 charset-normalizer==3.4.1
     # via requests
@@ -106,7 +106,7 @@ coverage==7.8.0
     #   localstack-core
 coveralls==4.0.1
     # via localstack-core
-crontab==1.0.1
+crontab==1.0.4
     # via localstack-core
 cryptography==44.0.2
     # via
@@ -164,7 +164,7 @@ h2==4.2.0
     #   localstack-twisted
 hpack==4.1.0
     # via h2
-httpcore==1.0.7
+httpcore==1.0.8
     # via httpx
 httpx==0.28.1
     # via localstack-core
@@ -274,7 +274,7 @@ mypy-boto3-appconfig==1.37.0
     # via boto3-stubs
 mypy-boto3-appconfigdata==1.37.0
     # via boto3-stubs
-mypy-boto3-application-autoscaling==1.37.0
+mypy-boto3-application-autoscaling==1.37.32
     # via boto3-stubs
 mypy-boto3-appsync==1.37.15
     # via boto3-stubs
@@ -286,7 +286,7 @@ mypy-boto3-backup==1.37.0
     # via boto3-stubs
 mypy-boto3-batch==1.37.22
     # via boto3-stubs
-mypy-boto3-ce==1.37.10
+mypy-boto3-ce==1.37.30
     # via boto3-stubs
 mypy-boto3-cloudcontrol==1.37.0
     # via boto3-stubs
@@ -318,7 +318,7 @@ mypy-boto3-dms==1.37.4
     # via boto3-stubs
 mypy-boto3-docdb==1.37.0
     # via boto3-stubs
-mypy-boto3-dynamodb==1.37.12
+mypy-boto3-dynamodb==1.37.33
     # via boto3-stubs
 mypy-boto3-dynamodbstreams==1.37.0
     # via boto3-stubs
@@ -332,7 +332,7 @@ mypy-boto3-efs==1.37.0
     # via boto3-stubs
 mypy-boto3-eks==1.37.24
     # via boto3-stubs
-mypy-boto3-elasticache==1.37.6
+mypy-boto3-elasticache==1.37.32
     # via boto3-stubs
 mypy-boto3-elasticbeanstalk==1.37.0
     # via boto3-stubs
@@ -352,7 +352,7 @@ mypy-boto3-fis==1.37.0
     # via boto3-stubs
 mypy-boto3-glacier==1.37.0
     # via boto3-stubs
-mypy-boto3-glue==1.37.29
+mypy-boto3-glue==1.37.31
     # via boto3-stubs
 mypy-boto3-iam==1.37.22
     # via boto3-stubs
@@ -460,7 +460,7 @@ mypy-boto3-timestream-write==1.37.0
     # via boto3-stubs
 mypy-boto3-transcribe==1.37.27
     # via boto3-stubs
-mypy-boto3-verifiedpermissions==1.37.0
+mypy-boto3-verifiedpermissions==1.37.33
     # via boto3-stubs
 mypy-boto3-wafv2==1.37.21
     # via boto3-stubs
@@ -485,7 +485,7 @@ openapi-spec-validator==0.7.1
     #   openapi-core
 opensearch-py==2.8.0
     # via localstack-core
-orderly-set==5.3.1
+orderly-set==5.4.0
     # via deepdiff
 packaging==24.2
     # via
@@ -541,13 +541,13 @@ pyasn1==0.6.1
     # via rsa
 pycparser==2.22
     # via cffi
-pydantic==2.11.2
+pydantic==2.11.3
     # via aws-sam-translator
 pydantic-core==2.33.1
     # via pydantic
 pygments==2.19.1
     # via rich
-pymongo==4.11.3
+pymongo==4.12.0
     # via localstack-core
 pyopenssl==25.0.0
     # via
@@ -565,7 +565,7 @@ pytest==8.3.5
     #   pytest-rerunfailures
     #   pytest-split
     #   pytest-tinybird
-pytest-httpserver==1.1.2
+pytest-httpserver==1.1.3
     # via localstack-core
 pytest-rerunfailures==15.0
     # via localstack-core
@@ -635,7 +635,7 @@ rsa==4.7.2
     # via awscli
 rstr==3.2.2
     # via localstack-core
-ruff==0.11.4
+ruff==0.11.5
     # via localstack-core
 s3transfer==0.11.4
     # via
@@ -667,11 +667,11 @@ typeguard==2.13.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-types-awscrt==0.25.7
+types-awscrt==0.26.1
     # via botocore-stubs
 types-s3transfer==0.11.4
     # via boto3-stubs
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   anyio
     #   aws-sam-translator
@@ -790,7 +790,7 @@ typing-extensions==4.13.1
     #   typing-inspection
 typing-inspection==0.4.0
     # via pydantic
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   botocore
     #   docker

--- a/requirements-typehint.txt
+++ b/requirements-typehint.txt
@@ -254,7 +254,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
     # via openapi-core
-moto-ext==5.1.1.post2
+moto-ext==5.1.3.post1
     # via localstack-core
 mpmath==1.3.0
     # via sympy

--- a/tests/aws/services/apigateway/apigateway_fixtures.py
+++ b/tests/aws/services/apigateway/apigateway_fixtures.py
@@ -35,38 +35,10 @@ def import_rest_api(apigateway_client, **kwargs):
     return response, root_id
 
 
-def get_rest_api(apigateway_client, **kwargs):
-    response = apigateway_client.get_rest_api(**kwargs)
-    assert_response_is_200(response)
-    return response.get("id"), response.get("name")
-
-
-def put_rest_api(apigateway_client, **kwargs):
-    response = apigateway_client.put_rest_api(**kwargs)
-    assert_response_is_200(response)
-    return response.get("id"), response.get("name")
-
-
-def get_rest_apis(apigateway_client, **kwargs):
-    response = apigateway_client.get_rest_apis(**kwargs)
-    assert_response_is_200(response)
-    return response.get("items")
-
-
-def delete_rest_api(apigateway_client, **kwargs):
-    response = apigateway_client.delete_rest_api(**kwargs)
-    assert_response_status(response, 202)
-
-
 def create_rest_resource(apigateway_client, **kwargs):
     response = apigateway_client.create_resource(**kwargs)
     assert_response_is_201(response)
     return response.get("id"), response.get("parentId")
-
-
-def delete_rest_resource(apigateway_client, **kwargs):
-    response = apigateway_client.delete_resource(**kwargs)
-    assert_response_is_200(response)
 
 
 def create_rest_resource_method(apigateway_client, **kwargs):
@@ -75,32 +47,10 @@ def create_rest_resource_method(apigateway_client, **kwargs):
     return response.get("httpMethod"), response.get("authorizerId")
 
 
-def create_rest_authorizer(apigateway_client, **kwargs):
-    response = apigateway_client.create_authorizer(**kwargs)
-    assert_response_is_201(response)
-    return response.get("id"), response.get("type")
-
-
 def create_rest_api_integration(apigateway_client, **kwargs):
     response = apigateway_client.put_integration(**kwargs)
     assert_response_is_201(response)
     return response.get("uri"), response.get("type")
-
-
-def get_rest_api_resources(apigateway_client, **kwargs):
-    response = apigateway_client.get_resources(**kwargs)
-    assert_response_is_200(response)
-    return response.get("items")
-
-
-def delete_rest_api_integration(apigateway_client, **kwargs):
-    response = apigateway_client.delete_integration(**kwargs)
-    assert_response_is_200(response)
-
-
-def get_rest_api_integration(apigateway_client, **kwargs):
-    response = apigateway_client.get_integration(**kwargs)
-    assert_response_is_200(response)
 
 
 def create_rest_api_method_response(apigateway_client, **kwargs):
@@ -113,17 +63,6 @@ def create_rest_api_integration_response(apigateway_client, **kwargs):
     response = apigateway_client.put_integration_response(**kwargs)
     assert_response_is_201(response)
     return response.get("statusCode")
-
-
-def create_domain_name(apigateway_client, **kwargs):
-    response = apigateway_client.create_domain_name(**kwargs)
-    assert_response_is_201(response)
-
-
-def create_base_path_mapping(apigateway_client, **kwargs):
-    response = apigateway_client.create_base_path_mapping(**kwargs)
-    assert_response_is_201(response)
-    return response.get("basePath"), response.get("stage")
 
 
 def create_rest_api_deployment(apigateway_client, **kwargs):
@@ -148,47 +87,6 @@ def update_rest_api_stage(apigateway_client, **kwargs):
     response = apigateway_client.update_stage(**kwargs)
     assert_response_is_200(response)
     return response.get("stageName")
-
-
-def create_cognito_user_pool(cognito_idp, **kwargs):
-    response = cognito_idp.create_user_pool(**kwargs)
-    assert_response_is_200(response)
-    return response.get("UserPool").get("Id"), response.get("UserPool").get("Arn")
-
-
-def delete_cognito_user_pool(cognito_idp, **kwargs):
-    response = cognito_idp.delete_user_pool(**kwargs)
-    assert_response_is_200(response)
-
-
-def create_cognito_user_pool_client(cognito_idp, **kwargs):
-    response = cognito_idp.create_user_pool_client(**kwargs)
-    assert_response_is_200(response)
-    return (
-        response.get("UserPoolClient").get("ClientId"),
-        response.get("UserPoolClient").get("ClientName"),
-    )
-
-
-def create_cognito_user(cognito_idp, **kwargs):
-    response = cognito_idp.sign_up(**kwargs)
-    assert_response_is_200(response)
-
-
-def create_cognito_sign_up_confirmation(cognito_idp, **kwargs):
-    response = cognito_idp.admin_confirm_sign_up(**kwargs)
-    assert_response_is_200(response)
-
-
-def create_initiate_auth(cognito_idp, **kwargs):
-    response = cognito_idp.initiate_auth(**kwargs)
-    assert_response_is_200(response)
-    return response.get("AuthenticationResult").get("IdToken")
-
-
-def delete_cognito_user_pool_client(cognito_idp, **kwargs):
-    response = cognito_idp.delete_user_pool_client(**kwargs)
-    assert_response_is_200(response)
 
 
 #

--- a/tests/aws/services/apigateway/conftest.py
+++ b/tests/aws/services/apigateway/conftest.py
@@ -13,7 +13,6 @@ from tests.aws.services.apigateway.apigateway_fixtures import (
     create_rest_api_stage,
     create_rest_resource,
     create_rest_resource_method,
-    delete_rest_api,
     import_rest_api,
 )
 from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON_ECHO_STATUS_CODE
@@ -232,7 +231,7 @@ def import_apigw(aws_client, aws_client_factory):
     yield _import_apigateway_function
 
     for rest_api_id in rest_api_ids:
-        delete_rest_api(apigateway_client, restApiId=rest_api_id)
+        apigateway_client.delete_rest_api(restApiId=rest_api_id)
 
 
 @pytest.fixture

--- a/tests/aws/services/apigateway/test_apigateway_api.py
+++ b/tests/aws/services/apigateway/test_apigateway_api.py
@@ -2320,6 +2320,7 @@ class TestApigatewayTestInvoke:
                 lambda k, v: str(v) if k == "latency" else None, "latency", replace_reference=False
             )
         )
+        # TODO: maybe transformer `log` better
         snapshot.add_transformer(
             snapshot.transform.key_value("log", "log", reference_replacement=False)
         )

--- a/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
-    "recorded-date": "04-02-2024, 18:48:24",
+    "recorded-date": "11-04-2025, 18:02:16",
     "recorded-content": {
       "test_invoke_method_response": {
         "body": {
@@ -11,16 +11,36 @@
         },
         "headers": {
           "Content-Type": "application/json",
-          "X-Amzn-Trace-Id": "Root=1-65bfdbf7-1b5920a5a0a57e32194306b3;Parent=5c9925637b7d89fa;Sampled=0;lineage=59cc7ee1:0"
+          "X-Amzn-Trace-Id": "<x-amz-trace-id:1>"
         },
-        "latency": 394,
-        "log": "Execution log for request d09d726b-32a3-42fc-87c7-42ac58bca845\nSun Feb 04 18:48:23 UTC 2024 : Starting execution for request: d09d726b-32a3-42fc-87c7-42ac58bca845\nSun Feb 04 18:48:23 UTC 2024 : HTTP Method: GET, Resource Path: /foo\nSun Feb 04 18:48:23 UTC 2024 : Method request path: {}\nSun Feb 04 18:48:23 UTC 2024 : Method request query string: {}\nSun Feb 04 18:48:23 UTC 2024 : Method request headers: {}\nSun Feb 04 18:48:23 UTC 2024 : Method request body before transformations: \nSun Feb 04 18:48:23 UTC 2024 : Endpoint request URI: https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:test-de2a8789/invocations\nSun Feb 04 18:48:23 UTC 2024 : Endpoint request headers: {x-amzn-lambda-integration-tag=d09d726b-32a3-42fc-87c7-42ac58bca845, Authorization=*********************************************************************************************************************************************************************************************************************************************************************fd20ad, X-Amz-Date=20240204T184823Z, x-amzn-apigateway-api-id=96m844vit9, Accept=application/json, User-Agent=AmazonAPIGateway_96m844vit9, X-Amz-Security-Token=IQoJb3JpZ2luX2VjEMv//////////wEaCXVzLWVhc3QtMSJHMEUCIQDH/nm1y4gMfoEBmxGW3/Tvqy4n6O3lzViNg021ao2NOQIgXFf6aGDn2L5egYErKkRsBaOKEvTn/jpaZgmTjAGO1BEq7gIIlP//////////ARACGgw2NTk2NzY4MjExMTgiDGZzbbOVj3R7zPeswyrCAtEzQYGuVCS1ylMX93oVtpfyXNQx3ZLeknme7FtyuuFFuzM2lU+a3C4ykL4j8qQmT8nFXdfX7ZzLCLmRjr1EhTgPrh7SE5XSxfBQdxTQxkoaGImnDRbceKLPxSMALrub+owhkfeZT29laOyBzPdttLM7iG7Q/bws/ywC0I8HMJA4Dl5KHMhiKDBncYXjdYhlHCSPb+qN/5cZ1Wm+jUV/znw6RG8Hhz+mKzFDckbVItiRD+CdbP5V3IjVZgtzSvwXqN8EXN9R0tRXE+b0FD7AUMctWoDbCqkIHf [TRUNCATED]\nSun Feb 04 18:48:23 UTC 2024 : Endpoint request body after transformations: \nSun Feb 04 18:48:23 UTC 2024 : Sending request to https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:test-de2a8789/invocations\nSun Feb 04 18:48:24 UTC 2024 : Received response. Status: 200, Integration latency: 356 ms\nSun Feb 04 18:48:24 UTC 2024 : Endpoint response headers: {Date=Sun, 04 Feb 2024 18:48:24 GMT, Content-Type=application/json, Content-Length=104, Connection=keep-alive, x-amzn-RequestId=20a0cc6d-ade0-417f-853d-04c72dbe23d6, x-amzn-Remapped-Content-Length=0, X-Amz-Executed-Version=$LATEST, X-Amzn-Trace-Id=root=1-65bfdbf7-1b5920a5a0a57e32194306b3;parent=5c9925637b7d89fa;sampled=0;lineage=59cc7ee1:0}\nSun Feb 04 18:48:24 UTC 2024 : Endpoint response body before transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}\nSun Feb 04 18:48:24 UTC 2024 : Method response body after transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}\nSun Feb 04 18:48:24 UTC 2024 : Method response headers: {X-Amzn-Trace-Id=Root=1-65bfdbf7-1b5920a5a0a57e32194306b3;Parent=5c9925637b7d89fa;Sampled=0;lineage=59cc7ee1:0, Content-Type=application/json}\nSun Feb 04 18:48:24 UTC 2024 : Successfully completed execution\nSun Feb 04 18:48:24 UTC 2024 : Method completed with status: 200\n",
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-1>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-1>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /foo",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: ",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request URI: https://<endpoint_url>/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request headers: {x-amzn-lambda-integration-tag=<request-id-1>, Authorization=<authorization-header>, X-Amz-Date=<date>, x-amzn-apigateway-api-id=<rest-api-id>, Accept=application/json, User-Agent=AmazonAPIGateway_<rest-api-id>, X-Amz-Security-Token=<token> [TRUNCATED]",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request body after transformations: ",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Sending request to https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
+          "line11": "DDD MMM dd hh:mm:ss UTC yyyy : Received response. Status: 200, Integration latency: <latency> ms",
+          "line12": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint response headers: {Date=Day, dd MMM yyyy hh:mm:ss GMT, Content-Type=application/json, Content-Length=104, Connection=keep-alive, x-amzn-RequestId=<request-id-lambda>, x-amzn-Remapped-Content-Length=0, X-Amz-Executed-Version=$LATEST, X-Amzn-Trace-Id=<x-amz-trace-id:1>}",
+          "line13": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint response body before transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}",
+          "line14": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}",
+          "line15": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {X-Amzn-Trace-Id=<x-amz-trace-id:1>, Content-Type=application/json}",
+          "line16": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line17": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line18": ""
+        },
         "multiValueHeaders": {
           "Content-Type": [
             "application/json"
           ],
           "X-Amzn-Trace-Id": [
-            "Root=1-65bfdbf7-1b5920a5a0a57e32194306b3;Parent=5c9925637b7d89fa;Sampled=0;lineage=59cc7ee1:0"
+            "<x-amz-trace-id:1>"
           ]
         },
         "status": 200,
@@ -38,16 +58,36 @@
         },
         "headers": {
           "Content-Type": "application/json",
-          "X-Amzn-Trace-Id": "Root=1-65bfdbf8-caa70673935f456b40debcda;Parent=0f5819866f6639ce;Sampled=0;lineage=59cc7ee1:0"
+          "X-Amzn-Trace-Id": "<x-amz-trace-id:2>"
         },
-        "latency": 62,
-        "log": "Execution log for request 63ecf43a-1b6e-40ef-80b7-98c5b7484ec9\nSun Feb 04 18:48:24 UTC 2024 : Starting execution for request: 63ecf43a-1b6e-40ef-80b7-98c5b7484ec9\nSun Feb 04 18:48:24 UTC 2024 : HTTP Method: GET, Resource Path: /foo\nSun Feb 04 18:48:24 UTC 2024 : Method request path: {}\nSun Feb 04 18:48:24 UTC 2024 : Method request query string: {}\nSun Feb 04 18:48:24 UTC 2024 : Method request headers: {content-type=application/json}\nSun Feb 04 18:48:24 UTC 2024 : Method request body before transformations: {\"test\": \"val123\"}\nSun Feb 04 18:48:24 UTC 2024 : Endpoint request URI: https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:test-de2a8789/invocations\nSun Feb 04 18:48:24 UTC 2024 : Endpoint request headers: {x-amzn-lambda-integration-tag=63ecf43a-1b6e-40ef-80b7-98c5b7484ec9, Authorization=*******************************************************************************************************************************************************************************************************************************************************************************************************4b5ad4, X-Amz-Date=20240204T184824Z, x-amzn-apigateway-api-id=96m844vit9, Accept=application/json, User-Agent=AmazonAPIGateway_96m844vit9, X-Amz-Security-Token=IQoJb3JpZ2luX2VjEMv//////////wEaCXVzLWVhc3QtMSJIMEYCIQCX8aMq+Q5P6zw4SzP7nSzzMTzd2D0tbCwx9jyQnWiiSgIhAKevG8f4Qo1O/lr+A17AujqFg9AqJCIB5zNu+g8RZFl+Ku4CCJT//////////wEQAhoMNjU5Njc2ODIxMTE4IgxyHR1NVV6IvXrBrD8qwgJNyGLqGkyhoWFD36VE4ENpEW9PzKtbnKkQq/tqZdBBSwvzTmANSNEE7dIpiTolgXGMN4llNaV9CNYF+Ro/zXmsY4u/y8HgSFnTst/iOam+hEGQEr9BEflhu1Sqy7xqBt5pfIVscdpPNVsdX0OLKDT98v3pTRUnilsMDK/6F4wzl4SJ8mQ4vYqCN5mh6n+96Ze2Q0ldYEDjbBmMItgyDk2so2OxMiVPtrhJ81u7NYsEYdmgQ5dve3rQYT7+oVnA [TRUNCATED]\nSun Feb 04 18:48:24 UTC 2024 : Endpoint request body after transformations: {\"test\": \"val123\"}\nSun Feb 04 18:48:24 UTC 2024 : Sending request to https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:test-de2a8789/invocations\nSun Feb 04 18:48:24 UTC 2024 : Received response. Status: 200, Integration latency: 25 ms\nSun Feb 04 18:48:24 UTC 2024 : Endpoint response headers: {Date=Sun, 04 Feb 2024 18:48:24 GMT, Content-Type=application/json, Content-Length=131, Connection=keep-alive, x-amzn-RequestId=57dc53e3-bc2e-449b-83ef-fd7d97479909, x-amzn-Remapped-Content-Length=0, X-Amz-Executed-Version=$LATEST, X-Amzn-Trace-Id=root=1-65bfdbf8-caa70673935f456b40debcda;parent=0f5819866f6639ce;sampled=0;lineage=59cc7ee1:0}\nSun Feb 04 18:48:24 UTC 2024 : Endpoint response body before transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {\\\\\\\"test\\\\\\\":\\\\\\\"val123\\\\\\\"}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}\nSun Feb 04 18:48:24 UTC 2024 : Method response body after transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {\\\\\\\"test\\\\\\\":\\\\\\\"val123\\\\\\\"}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}\nSun Feb 04 18:48:24 UTC 2024 : Method response headers: {X-Amzn-Trace-Id=Root=1-65bfdbf8-caa70673935f456b40debcda;Parent=0f5819866f6639ce;Sampled=0;lineage=59cc7ee1:0, Content-Type=application/json}\nSun Feb 04 18:48:24 UTC 2024 : Successfully completed execution\nSun Feb 04 18:48:24 UTC 2024 : Method completed with status: 200\n",
+        "latency": "<latency>",
+        "log": {
+          "line00": "Execution log for request <request-id-2>",
+          "line01": "DDD MMM dd hh:mm:ss UTC yyyy : Starting execution for request: <request-id-2>",
+          "line02": "DDD MMM dd hh:mm:ss UTC yyyy : HTTP Method: GET, Resource Path: /foo",
+          "line03": "DDD MMM dd hh:mm:ss UTC yyyy : Method request path: {}",
+          "line04": "DDD MMM dd hh:mm:ss UTC yyyy : Method request query string: {queryTest=value}",
+          "line05": "DDD MMM dd hh:mm:ss UTC yyyy : Method request headers: {content-type=application/json}",
+          "line06": "DDD MMM dd hh:mm:ss UTC yyyy : Method request body before transformations: {\"test\": \"val123\"}",
+          "line07": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request URI: https://<endpoint_url>/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
+          "line08": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request headers: {x-amzn-lambda-integration-tag=<request-id-2>, Authorization=<authorization-header>, X-Amz-Date=<date>, x-amzn-apigateway-api-id=<rest-api-id>, Accept=application/json, User-Agent=AmazonAPIGateway_<rest-api-id>, X-Amz-Security-Token=<token> [TRUNCATED]",
+          "line09": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint request body after transformations: {\"test\": \"val123\"}",
+          "line10": "DDD MMM dd hh:mm:ss UTC yyyy : Sending request to https://lambda.<region>.amazonaws.com/2015-03-31/functions/arn:<partition>:lambda:<region>:111111111111:function:<function-name>/invocations",
+          "line11": "DDD MMM dd hh:mm:ss UTC yyyy : Received response. Status: 200, Integration latency: <latency> ms",
+          "line12": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint response headers: {Date=Day, dd MMM yyyy hh:mm:ss GMT, Content-Type=application/json, Content-Length=131, Connection=keep-alive, x-amzn-RequestId=<request-id-lambda>, x-amzn-Remapped-Content-Length=0, X-Amz-Executed-Version=$LATEST, X-Amzn-Trace-Id=<x-amz-trace-id:2>}",
+          "line13": "DDD MMM dd hh:mm:ss UTC yyyy : Endpoint response body before transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {\\\\\\\"test\\\\\\\":\\\\\\\"val123\\\\\\\"}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}",
+          "line14": "DDD MMM dd hh:mm:ss UTC yyyy : Method response body after transformations: {\"statusCode\":200,\"body\":\"\\\"response from localstack lambda: {\\\\\\\"test\\\\\\\":\\\\\\\"val123\\\\\\\"}\\\"\",\"isBase64Encoded\":false,\"headers\":{}}",
+          "line15": "DDD MMM dd hh:mm:ss UTC yyyy : Method response headers: {X-Amzn-Trace-Id=<x-amz-trace-id:2>, Content-Type=application/json}",
+          "line16": "DDD MMM dd hh:mm:ss UTC yyyy : Successfully completed execution",
+          "line17": "DDD MMM dd hh:mm:ss UTC yyyy : Method completed with status: 200",
+          "line18": ""
+        },
         "multiValueHeaders": {
           "Content-Type": [
             "application/json"
           ],
           "X-Amzn-Trace-Id": [
-            "Root=1-65bfdbf8-caa70673935f456b40debcda;Parent=0f5819866f6639ce;Sampled=0;lineage=59cc7ee1:0"
+            "<x-amz-trace-id:2>"
           ]
         },
         "status": 200,

--- a/tests/aws/services/apigateway/test_apigateway_basic.validation.json
+++ b/tests/aws/services/apigateway/test_apigateway_basic.validation.json
@@ -15,7 +15,7 @@
     "last_validated_date": "2024-07-12T20:04:15+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_apigw_test_invoke_method_api": {
-    "last_validated_date": "2024-02-04T18:48:24+00:00"
+    "last_validated_date": "2025-04-11T18:03:13+00:00"
   },
   "tests/aws/services/apigateway/test_apigateway_basic.py::TestAPIGateway::test_update_rest_api_deployment": {
     "last_validated_date": "2024-04-12T21:24:49+00:00"

--- a/tests/aws/services/cloudformation/api/test_changesets.py
+++ b/tests/aws/services/cloudformation/api/test_changesets.py
@@ -1526,10 +1526,6 @@ class TestCaptureUpdateProcess:
         capture_update_process(snapshot, t1, t1, p1={"TopicName": "key1"}, p2={"TopicName": "key2"})
 
     @markers.aws.validated
-    @pytest.mark.skip(
-        "Template deployment appears to fail on v2 due to unresolved resource dependencies; "
-        "this should be addressed in the development of the v2 engine executor."
-    )
     def test_conditions(
         self,
         snapshot,
@@ -1695,7 +1691,6 @@ class TestCaptureUpdateProcess:
         capture_update_process(snapshot, t1, t2)
 
     @markers.aws.validated
-    # @pytest.mark.skip("Executor is WIP")
     @pytest.mark.parametrize(
         "template",
         [
@@ -1718,101 +1713,106 @@ class TestCaptureUpdateProcess:
                 },
                 id="change_dynamic",
             ),
-            # pytest.param(
-            #     {
-            #         "Parameters": {
-            #             "ParameterValue": {
-            #                 "Type": "String",
-            #             },
-            #         },
-            #         "Resources": {
-            #             "Parameter1": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Properties": {
-            #                     "Name": "param-name",
-            #                     "Type": "String",
-            #                     "Value": {"Ref": "ParameterValue"},
-            #                 },
-            #             },
-            #             "Parameter2": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Properties": {
-            #                     "Type": "String",
-            #                     "Value": {"Fn::GetAtt": ["Parameter1", "Name"]},
-            #                 },
-            #             },
-            #         },
-            #     },
-            #     id="change_unrelated_property",
-            # ),
-            # pytest.param(
-            #     {
-            #         "Parameters": {
-            #             "ParameterValue": {
-            #                 "Type": "String",
-            #             },
-            #         },
-            #         "Resources": {
-            #             "Parameter1": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Properties": {
-            #                     "Type": "String",
-            #                     "Value": {"Ref": "ParameterValue"},
-            #                 },
-            #             },
-            #             "Parameter2": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Properties": {
-            #                     "Type": "String",
-            #                     "Value": {"Fn::GetAtt": ["Parameter1", "Type"]},
-            #                 },
-            #             },
-            #         },
-            #     },
-            #     id="change_unrelated_property_not_create_only",
-            # ),
-            # pytest.param(
-            #     {
-            #         "Parameters": {
-            #             "ParameterValue": {
-            #                 "Type": "String",
-            #                 "Default": "value-1",
-            #                 "AllowedValues": ["value-1", "value-2"],
-            #             }
-            #         },
-            #         "Conditions": {
-            #             "ShouldCreateParameter": {
-            #                 "Fn::Equals": [{"Ref": "ParameterValue"}, "value-2"]
-            #             }
-            #         },
-            #         "Resources": {
-            #             "SSMParameter1": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Properties": {
-            #                     "Type": "String",
-            #                     "Value": "first",
-            #                 },
-            #             },
-            #             "SSMParameter2": {
-            #                 "Type": "AWS::SSM::Parameter",
-            #                 "Condition": "ShouldCreateParameter",
-            #                 "Properties": {
-            #                     "Type": "String",
-            #                     "Value": "first",
-            #                 },
-            #             },
-            #         },
-            #     },
-            #     id="change_parameter_for_condition_create_resource",
-            # ),
+            pytest.param(
+                {
+                    "Parameters": {
+                        "ParameterValue": {
+                            "Type": "String",
+                        },
+                    },
+                    "Resources": {
+                        "Parameter1": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Properties": {
+                                "Name": "param-name",
+                                "Type": "String",
+                                "Value": {"Ref": "ParameterValue"},
+                            },
+                        },
+                        "Parameter2": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Properties": {
+                                "Type": "String",
+                                "Value": {"Fn::GetAtt": ["Parameter1", "Name"]},
+                            },
+                        },
+                    },
+                },
+                id="change_unrelated_property",
+            ),
+            pytest.param(
+                {
+                    "Parameters": {
+                        "ParameterValue": {
+                            "Type": "String",
+                        },
+                    },
+                    "Resources": {
+                        "Parameter1": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Properties": {
+                                "Type": "String",
+                                "Value": {"Ref": "ParameterValue"},
+                            },
+                        },
+                        "Parameter2": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Properties": {
+                                "Type": "String",
+                                "Value": {"Fn::GetAtt": ["Parameter1", "Type"]},
+                            },
+                        },
+                    },
+                },
+                id="change_unrelated_property_not_create_only",
+            ),
+            pytest.param(
+                {
+                    "Parameters": {
+                        "ParameterValue": {
+                            "Type": "String",
+                            "Default": "value-1",
+                            "AllowedValues": ["value-1", "value-2"],
+                        }
+                    },
+                    "Conditions": {
+                        "ShouldCreateParameter": {
+                            "Fn::Equals": [{"Ref": "ParameterValue"}, "value-2"]
+                        }
+                    },
+                    "Resources": {
+                        "SSMParameter1": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Properties": {
+                                "Type": "String",
+                                "Value": "first",
+                            },
+                        },
+                        "SSMParameter2": {
+                            "Type": "AWS::SSM::Parameter",
+                            "Condition": "ShouldCreateParameter",
+                            "Properties": {
+                                "Type": "String",
+                                "Value": "first",
+                            },
+                        },
+                    },
+                },
+                id="change_parameter_for_condition_create_resource",
+            ),
         ],
     )
     def test_base_dynamic_parameter_scenarios(
-        self,
-        snapshot,
-        capture_update_process,
-        template,
+        self, snapshot, capture_update_process, template, request
     ):
+        if request.node.callspec.id in {
+            "change_unrelated_property",
+            "change_unrelated_property_not_create_only",
+        }:
+            pytest.skip(
+                reason="AWS appears to incorrectly mark the dependent resource as needing update when describe "
+                "changeset is invoked without the inclusion of property values."
+            )
         capture_update_process(
             snapshot,
             template,
@@ -1866,7 +1866,6 @@ class TestCaptureUpdateProcess:
         snapshot.match("after-value", after_value)
 
     @markers.aws.validated
-    @pytest.mark.skip("Executor is WIP")
     @pytest.mark.parametrize(
         "template_1, template_2",
         [

--- a/tests/aws/services/cloudformation/api/test_changesets.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.snapshot.json
@@ -7261,5 +7261,27 @@
         "Tags": []
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::TestCaptureUpdateProcess::test_execute_with_ref": {
+    "recorded-date": "11-04-2025, 14:34:15",
+    "recorded-content": {
+      "before-value": "<name-1>",
+      "after-value": "<name-2>"
+    }
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::TestUpdates::test_deleting_resource": {
+    "recorded-date": "15-04-2025, 15:07:18",
+    "recorded-content": {
+      "get-parameter-error": {
+        "Error": {
+          "Code": "ParameterNotFound",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_changesets.validation.json
+++ b/tests/aws/services/cloudformation/api/test_changesets.validation.json
@@ -23,6 +23,9 @@
   "tests/aws/services/cloudformation/api/test_changesets.py::TestCaptureUpdateProcess::test_dynamic_update": {
     "last_validated_date": "2025-04-01T12:30:53+00:00"
   },
+  "tests/aws/services/cloudformation/api/test_changesets.py::TestCaptureUpdateProcess::test_execute_with_ref": {
+    "last_validated_date": "2025-04-11T14:34:09+00:00"
+  },
   "tests/aws/services/cloudformation/api/test_changesets.py::TestCaptureUpdateProcess::test_mappings_with_parameter_lookup": {
     "last_validated_date": "2025-04-01T13:31:33+00:00"
   },
@@ -37,6 +40,9 @@
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::TestCaptureUpdateProcess::test_unrelated_changes_update_propagation": {
     "last_validated_date": "2025-04-01T16:40:03+00:00"
+  },
+  "tests/aws/services/cloudformation/api/test_changesets.py::TestUpdates::test_deleting_resource": {
+    "last_validated_date": "2025-04-15T15:07:18+00:00"
   },
   "tests/aws/services/cloudformation/api/test_changesets.py::TestUpdates::test_simple_update_two_resources": {
     "last_validated_date": "2025-04-02T10:05:26+00:00"

--- a/tests/aws/services/cloudformation/resources/test_ec2.py
+++ b/tests/aws/services/cloudformation/resources/test_ec2.py
@@ -155,6 +155,8 @@ def test_dhcp_options(aws_client, deploy_cfn_template, snapshot):
         "$..Tags",
         "$..Options.AssociationDefaultRouteTableId",
         "$..Options.PropagationDefaultRouteTableId",
+        "$..Options.TransitGatewayCidrBlocks",  # an empty list returned by Moto but not by AWS
+        "$..Options.SecurityGroupReferencingSupport",  # not supported by Moto
     ]
 )
 def test_transit_gateway_attachment(deploy_cfn_template, aws_client, snapshot):

--- a/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.snapshot.json
@@ -91,7 +91,7 @@
     }
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_transit_gateway_attachment": {
-    "recorded-date": "28-03-2024, 06:48:11",
+    "recorded-date": "08-04-2025, 10:51:02",
     "recorded-content": {
       "attachment": {
         "Association": {
@@ -125,6 +125,7 @@
           "DnsSupport": "enable",
           "MulticastSupport": "disable",
           "PropagationDefaultRouteTableId": "<transit-gateway-route-table-id:1>",
+          "SecurityGroupReferencingSupport": "disable",
           "VpnEcmpSupport": "enable"
         },
         "OwnerId": "111111111111",

--- a/tests/aws/services/cloudformation/resources/test_ec2.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_ec2.validation.json
@@ -24,7 +24,7 @@
     "last_validated_date": "2024-07-01T20:10:52+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_transit_gateway_attachment": {
-    "last_validated_date": "2024-03-28T06:48:11+00:00"
+    "last_validated_date": "2025-04-08T10:51:02+00:00"
   },
   "tests/aws/services/cloudformation/resources/test_ec2.py::test_vpc_creates_default_sg": {
     "last_validated_date": "2024-04-01T11:21:54+00:00"

--- a/tests/aws/services/cloudformation/v2/test_change_set_conditions.py
+++ b/tests/aws/services/cloudformation/v2/test_change_set_conditions.py
@@ -1,0 +1,180 @@
+import pytest
+from localstack_snapshot.snapshots.transformer import RegexTransformer
+
+from localstack.services.cloudformation.v2.utils import is_v2_engine
+from localstack.testing.pytest import markers
+from localstack.utils.strings import long_uid
+
+
+@pytest.mark.skipif(condition=not is_v2_engine(), reason="Requires the V2 engine")
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        "per-resource-events..*",
+        "delete-describe..*",
+        #
+        "$..ChangeSetId",  # An issue for the WIP executor
+        # Before/After Context
+        "$..Capabilities",
+        "$..NotificationARNs",
+        "$..IncludeNestedStacks",
+        "$..Scope",
+        "$..Details",
+        "$..Parameters",
+        "$..Replacement",
+        "$..PolicyAction",
+        "$..PhysicalResourceId",
+    ]
+)
+class TestChangeSetConditions:
+    @markers.aws.validated
+    @pytest.mark.skip(
+        reason="The inclusion of response parameters in executor is in progress, "
+        "currently it cannot delete due to missing topic arn in the request"
+    )
+    def test_condition_update_removes_resource(
+        self,
+        snapshot,
+        capture_update_process,
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        name2 = f"topic-name-2-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+        snapshot.add_transformer(RegexTransformer(name2, "topic-name-2"))
+        template_1 = {
+            "Conditions": {"CreateTopic": {"Fn::Equals": ["true", "true"]}},
+            "Resources": {
+                "SNSTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Condition": "CreateTopic",
+                    "Properties": {"TopicName": name1},
+                }
+            },
+        }
+        template_2 = {
+            "Conditions": {"CreateTopic": {"Fn::Equals": ["true", "false"]}},
+            "Resources": {
+                "SNSTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Condition": "CreateTopic",
+                    "Properties": {"TopicName": name1},
+                },
+                "TopicPlaceholder": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name2},
+                },
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_condition_update_adds_resource(
+        self,
+        snapshot,
+        capture_update_process,
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        name2 = f"topic-name-2-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+        snapshot.add_transformer(RegexTransformer(name2, "topic-name-2"))
+        template_1 = {
+            "Conditions": {"CreateTopic": {"Fn::Equals": ["true", "false"]}},
+            "Resources": {
+                "SNSTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Condition": "CreateTopic",
+                    "Properties": {"TopicName": name1},
+                },
+                "TopicPlaceholder": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name2},
+                },
+            },
+        }
+        template_2 = {
+            "Conditions": {"CreateTopic": {"Fn::Equals": ["true", "true"]}},
+            "Resources": {
+                "SNSTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Condition": "CreateTopic",
+                    "Properties": {"TopicName": name1},
+                },
+                "TopicPlaceholder": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name2},
+                },
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    @pytest.mark.skip(
+        reason="The inclusion of response parameters in executor is in progress, "
+        "currently it cannot delete due to missing topic arn in the request"
+    )
+    def test_condition_add_new_negative_condition_to_existent_resource(
+        self,
+        snapshot,
+        capture_update_process,
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        name2 = f"topic-name-2-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+        snapshot.add_transformer(RegexTransformer(name2, "topic-name-2"))
+        template_1 = {
+            "Resources": {
+                "SNSTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name1},
+                },
+            },
+        }
+        template_2 = {
+            "Conditions": {"CreateTopic": {"Fn::Equals": ["true", "false"]}},
+            "Resources": {
+                "SNSTopic": {
+                    "Type": "AWS::SNS::Topic",
+                    "Condition": "CreateTopic",
+                    "Properties": {"TopicName": name1},
+                },
+                "TopicPlaceholder": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name2},
+                },
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_condition_add_new_positive_condition_to_existent_resource(
+        self,
+        snapshot,
+        capture_update_process,
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        name2 = f"topic-name-2-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+        snapshot.add_transformer(RegexTransformer(name2, "topic-name-2"))
+        template_1 = {
+            "Resources": {
+                "SNSTopic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {"TopicName": name1},
+                },
+            },
+        }
+        template_2 = {
+            "Conditions": {"CreateTopic": {"Fn::Equals": ["true", "true"]}},
+            "Resources": {
+                "SNSTopic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Condition": "CreateTopic",
+                    "Properties": {"TopicName": name1},
+                },
+                "SNSTopic2": {
+                    "Type": "AWS::SNS::Topic",
+                    "Condition": "CreateTopic",
+                    "Properties": {"TopicName": name2},
+                },
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)

--- a/tests/aws/services/cloudformation/v2/test_change_set_conditions.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/test_change_set_conditions.snapshot.json
@@ -1,0 +1,1536 @@
+{
+  "tests/aws/services/cloudformation/v2/test_change_set_conditions.py::TestChangeSetConditions::test_condition_update_removes_resource": {
+    "recorded-date": "15-04-2025, 13:51:50",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "SNSTopic",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "SNSTopic",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Remove",
+              "BeforeContext": {
+                "Properties": {
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "SNSTopic",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "TopicPlaceholder",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Remove",
+              "Details": [],
+              "LogicalResourceId": "SNSTopic",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "TopicPlaceholder",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "SNSTopic": [
+          {
+            "EventId": "SNSTopic-c494ee19-3e85-4cf7-b823-5b706137c086",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic-f1a45cee-c917-4856-9b04-fdfa3d210cf3",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic-CREATE_COMPLETE-date",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "TopicPlaceholder": [
+          {
+            "EventId": "TopicPlaceholder-CREATE_COMPLETE-date",
+            "LogicalResourceId": "TopicPlaceholder",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "TopicPlaceholder-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "TopicPlaceholder",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "TopicPlaceholder-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "TopicPlaceholder",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_conditions.py::TestChangeSetConditions::test_condition_update_adds_resource": {
+    "recorded-date": "15-04-2025, 14:31:36",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "TopicPlaceholder",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "TopicPlaceholder",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "SNSTopic",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "SNSTopic",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "SNSTopic": [
+          {
+            "EventId": "SNSTopic-CREATE_COMPLETE-date",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "TopicPlaceholder": [
+          {
+            "EventId": "TopicPlaceholder-CREATE_COMPLETE-date",
+            "LogicalResourceId": "TopicPlaceholder",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "TopicPlaceholder-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "TopicPlaceholder",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "TopicPlaceholder-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "TopicPlaceholder",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_conditions.py::TestChangeSetConditions::test_condition_add_new_negative_condition_to_existent_resource": {
+    "recorded-date": "15-04-2025, 15:11:48",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "SNSTopic",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "SNSTopic",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Remove",
+              "BeforeContext": {
+                "Properties": {
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "SNSTopic",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "TopicPlaceholder",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Remove",
+              "Details": [],
+              "LogicalResourceId": "SNSTopic",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "PolicyAction": "Delete",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "TopicPlaceholder",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "SNSTopic": [
+          {
+            "EventId": "SNSTopic-c5786633-a3d3-43cc-8c5d-f504661d0578",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "DELETE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic-fb082f5d-2aee-49f6-9eb3-613c40aafad9",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceStatus": "DELETE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic-CREATE_COMPLETE-date",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "SNSTopic",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "TopicPlaceholder": [
+          {
+            "EventId": "TopicPlaceholder-CREATE_COMPLETE-date",
+            "LogicalResourceId": "TopicPlaceholder",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "TopicPlaceholder-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "TopicPlaceholder",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "TopicPlaceholder-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "TopicPlaceholder",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_conditions.py::TestChangeSetConditions::test_condition_add_new_positive_condition_to_existent_resource": {
+    "recorded-date": "15-04-2025, 16:00:40",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "SNSTopic1",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "SNSTopic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "SNSTopic2",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "SNSTopic2",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "SNSTopic1": [
+          {
+            "EventId": "SNSTopic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "SNSTopic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "SNSTopic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "SNSTopic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "SNSTopic2": [
+          {
+            "EventId": "SNSTopic2-CREATE_COMPLETE-date",
+            "LogicalResourceId": "SNSTopic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "SNSTopic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "SNSTopic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "SNSTopic2",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  }
+}

--- a/tests/aws/services/cloudformation/v2/test_change_set_conditions.validation.json
+++ b/tests/aws/services/cloudformation/v2/test_change_set_conditions.validation.json
@@ -1,0 +1,14 @@
+{
+  "tests/aws/services/cloudformation/v2/test_change_set_conditions.py::TestChangeSetConditions::test_condition_add_new_negative_condition_to_existent_resource": {
+    "last_validated_date": "2025-04-15T15:11:48+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_conditions.py::TestChangeSetConditions::test_condition_add_new_positive_condition_to_existent_resource": {
+    "last_validated_date": "2025-04-15T16:00:39+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_conditions.py::TestChangeSetConditions::test_condition_update_adds_resource": {
+    "last_validated_date": "2025-04-15T14:31:36+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_conditions.py::TestChangeSetConditions::test_condition_update_removes_resource": {
+    "last_validated_date": "2025-04-15T13:51:50+00:00"
+  }
+}

--- a/tests/aws/services/cloudformation/v2/test_change_set_mappings.py
+++ b/tests/aws/services/cloudformation/v2/test_change_set_mappings.py
@@ -1,0 +1,302 @@
+import pytest
+from localstack_snapshot.snapshots.transformer import RegexTransformer
+
+from localstack.services.cloudformation.v2.utils import is_v2_engine
+from localstack.testing.pytest import markers
+from localstack.utils.strings import long_uid
+
+
+@pytest.mark.skipif(condition=not is_v2_engine(), reason="Requires the V2 engine")
+@markers.snapshot.skip_snapshot_verify(
+    paths=[
+        "per-resource-events..*",
+        "delete-describe..*",
+        #
+        "$..ChangeSetId",  # An issue for the WIP executor
+        # Before/After Context
+        "$..Capabilities",
+        "$..NotificationARNs",
+        "$..IncludeNestedStacks",
+        "$..Scope",
+        "$..Details",
+        "$..Parameters",
+        "$..Replacement",
+        "$..PolicyAction",
+        "$..PhysicalResourceId",
+    ]
+)
+class TestChangeSetMappings:
+    @markers.aws.validated
+    def test_mapping_leaf_update(
+        self,
+        snapshot,
+        capture_update_process,
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+        template_1 = {
+            "Mappings": {"SNSMapping": {"Key1": {"Val": "display-value-1"}}},
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                }
+            },
+        }
+        template_2 = {
+            "Mappings": {"SNSMapping": {"Key1": {"Val": "display-value-2"}}},
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                }
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_mapping_key_update(
+        self,
+        snapshot,
+        capture_update_process,
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+        template_1 = {
+            "Mappings": {"SNSMapping": {"Key1": {"Val": "display-value-1"}}},
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                }
+            },
+        }
+        template_2 = {
+            "Mappings": {"SNSMapping": {"KeyNew": {"Val": "display-value-2"}}},
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "KeyNew", "Val"]},
+                    },
+                }
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_mapping_addition_with_resource(
+        self,
+        snapshot,
+        capture_update_process,
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        name2 = f"topic-name-2-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+        snapshot.add_transformer(RegexTransformer(name2, "topic-name-2"))
+        template_1 = {
+            "Mappings": {"SNSMapping": {"Key1": {"Val": "display-value-1"}}},
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                }
+            },
+        }
+        template_2 = {
+            "Mappings": {
+                "SNSMapping": {"Key1": {"Val": "display-value-1", "ValNew": "display-value-new"}}
+            },
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                },
+                "Topic2": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name2,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "ValNew"]},
+                    },
+                },
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_mapping_key_addition_with_resource(
+        self,
+        snapshot,
+        capture_update_process,
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        name2 = f"topic-name-2-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+        snapshot.add_transformer(RegexTransformer(name2, "topic-name-2"))
+        template_1 = {
+            "Mappings": {"SNSMapping": {"Key1": {"Val": "display-value-1"}}},
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                }
+            },
+        }
+        template_2 = {
+            "Mappings": {
+                "SNSMapping": {
+                    "Key1": {
+                        "Val": "display-value-1",
+                    },
+                    "Key2": {
+                        "Val": "display-value-1",
+                        "ValNew": "display-value-new",
+                    },
+                }
+            },
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key2", "Val"]},
+                    },
+                },
+                "Topic2": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name2,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key2", "ValNew"]},
+                    },
+                },
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_mapping_deletion_with_resource_remap(
+        self,
+        snapshot,
+        capture_update_process,
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        name2 = f"topic-name-2-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+        snapshot.add_transformer(RegexTransformer(name2, "topic-name-2"))
+        template_1 = {
+            "Mappings": {
+                "SNSMapping": {"Key1": {"Val": "display-value-1", "ValNew": "display-value-new"}}
+            },
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                },
+                "Topic2": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name2,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "ValNew"]},
+                    },
+                },
+            },
+        }
+        template_2 = {
+            "Mappings": {"SNSMapping": {"Key1": {"Val": "display-value-1"}}},
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                },
+                "Topic2": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name2,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                },
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)
+
+    @markers.aws.validated
+    def test_mapping_key_deletion_with_resource_remap(
+        self,
+        snapshot,
+        capture_update_process,
+    ):
+        name1 = f"topic-name-1-{long_uid()}"
+        name2 = f"topic-name-2-{long_uid()}"
+        snapshot.add_transformer(RegexTransformer(name1, "topic-name-1"))
+        snapshot.add_transformer(RegexTransformer(name2, "topic-name-2"))
+        template_1 = {
+            "Mappings": {
+                "SNSMapping": {
+                    "Key1": {
+                        "Val": "display-value-1",
+                    },
+                    "Key2": {"Val": "display-value-2"},
+                }
+            },
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                },
+                "Topic2": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name2,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key2", "Val"]},
+                    },
+                },
+            },
+        }
+        template_2 = {
+            "Mappings": {"SNSMapping": {"Key1": {"Val": "display-value-1"}}},
+            "Resources": {
+                "Topic1": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name1,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                },
+                "Topic2": {
+                    "Type": "AWS::SNS::Topic",
+                    "Properties": {
+                        "TopicName": name2,
+                        "DisplayName": {"Fn::FindInMap": ["SNSMapping", "Key1", "Val"]},
+                    },
+                },
+            },
+        }
+        capture_update_process(snapshot, template_1, template_2)

--- a/tests/aws/services/cloudformation/v2/test_change_set_mappings.snapshot.json
+++ b/tests/aws/services/cloudformation/v2/test_change_set_mappings.snapshot.json
@@ -1,0 +1,2428 @@
+{
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_leaf_update": {
+    "recorded-date": "15-04-2025, 13:03:18",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-2",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "display-value-2",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "display-value-1",
+                    "Name": "DisplayName",
+                    "Path": "/Properties/DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-2",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-2",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_key_update": {
+    "recorded-date": "15-04-2025, 13:04:44",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-2",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "display-value-2",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "display-value-1",
+                    "Name": "DisplayName",
+                    "Path": "/Properties/DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic1",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-2",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-2",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_addition_with_resource": {
+    "recorded-date": "15-04-2025, 13:05:52",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-new",
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Topic2": [
+          {
+            "EventId": "Topic2-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-new",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-new",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-new",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_key_addition_with_resource": {
+    "recorded-date": "15-04-2025, 13:07:01",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-new",
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Topic2": [
+          {
+            "EventId": "Topic2-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-new",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-new",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-new",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_deletion_with_resource_remap": {
+    "recorded-date": "15-04-2025, 13:08:27",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-new",
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "DisplayName": "display-value-new",
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "display-value-1",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "display-value-new",
+                    "Name": "DisplayName",
+                    "Path": "/Properties/DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic2",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic2",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Topic2": [
+          {
+            "EventId": "Topic2-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-new",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-new",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-new",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_key_deletion_with_resource_remap": {
+    "recorded-date": "15-04-2025, 13:15:54",
+    "recorded-content": {
+      "create-change-set-1": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-1"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-2",
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "Replacement": "True",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-1": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic1",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          },
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "Topic2",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-1-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "create-change-set-2": {
+        "Id": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2-prop-values": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "AfterContext": {
+                "Properties": {
+                  "DisplayName": "display-value-1",
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "BeforeContext": {
+                "Properties": {
+                  "DisplayName": "display-value-2",
+                  "TopicName": "topic-name-2"
+                }
+              },
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "AfterValue": "display-value-1",
+                    "Attribute": "Properties",
+                    "AttributeChangeType": "Modify",
+                    "BeforeValue": "display-value-2",
+                    "Name": "DisplayName",
+                    "Path": "/Properties/DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic2",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-change-set-2": {
+        "Capabilities": [],
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Modify",
+              "Details": [
+                {
+                  "ChangeSource": "DirectModification",
+                  "Evaluation": "Static",
+                  "Target": {
+                    "Attribute": "Properties",
+                    "Name": "DisplayName",
+                    "RequiresRecreation": "Never"
+                  }
+                }
+              ],
+              "LogicalResourceId": "Topic2",
+              "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+              "Replacement": "False",
+              "ResourceType": "AWS::SNS::Topic",
+              "Scope": [
+                "Properties"
+              ]
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "execute-change-set-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "post-create-2-describe": {
+        "ChangeSetId": "arn:<partition>:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "per-resource-events": {
+        "Topic1": [
+          {
+            "EventId": "Topic1-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-1",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic1-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic1",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-1"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "Topic2": [
+          {
+            "EventId": "Topic2-UPDATE_COMPLETE-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-UPDATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-1",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_COMPLETE-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-2",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "arn:<partition>:sns:<region>:111111111111:topic-name-2",
+            "ResourceProperties": {
+              "DisplayName": "display-value-2",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "Topic2-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "Topic2",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "DisplayName": "display-value-2",
+              "TopicName": "topic-name-2"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ],
+        "<stack-name:1>": [
+          {
+            "EventId": "<uuid:1>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:2>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:3>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "UPDATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:5>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:6>",
+            "LogicalResourceId": "<stack-name:1>",
+            "PhysicalResourceId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
+            "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      },
+      "delete-describe": {
+        "CreationTime": "datetime",
+        "DeletionTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:<partition>:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "DELETE_COMPLETE",
+        "Tags": []
+      }
+    }
+  }
+}

--- a/tests/aws/services/cloudformation/v2/test_change_set_mappings.validation.json
+++ b/tests/aws/services/cloudformation/v2/test_change_set_mappings.validation.json
@@ -1,0 +1,20 @@
+{
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_addition_with_resource": {
+    "last_validated_date": "2025-04-15T13:05:52+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_deletion_with_resource_remap": {
+    "last_validated_date": "2025-04-15T13:08:27+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_key_addition_with_resource": {
+    "last_validated_date": "2025-04-15T13:07:01+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_key_deletion_with_resource_remap": {
+    "last_validated_date": "2025-04-15T13:15:54+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_key_update": {
+    "last_validated_date": "2025-04-15T13:04:43+00:00"
+  },
+  "tests/aws/services/cloudformation/v2/test_change_set_mappings.py::TestChangeSetMappings::test_mapping_leaf_update": {
+    "last_validated_date": "2025-04-15T13:03:18+00:00"
+  }
+}

--- a/tests/aws/services/events/test_x_ray_trace_propagation.py
+++ b/tests/aws/services/events/test_x_ray_trace_propagation.py
@@ -1,0 +1,434 @@
+import json
+import time
+
+from localstack.aws.api.lambda_ import Runtime
+from localstack.testing.pytest import markers
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
+from localstack.utils.testutil import check_expected_lambda_log_events_length
+from localstack.utils.xray.trace_header import TraceHeader
+from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_AWS_PROXY_FORMAT
+
+APIGATEWAY_ASSUME_ROLE_POLICY = {
+    "Statement": {
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {"Service": "apigateway.amazonaws.com"},
+        "Action": "sts:AssumeRole",
+    }
+}
+import re
+
+import pytest
+
+from localstack.testing.aws.util import is_aws_cloud
+from tests.aws.services.events.helper_functions import is_old_provider
+from tests.aws.services.events.test_events import TEST_EVENT_DETAIL, TEST_EVENT_PATTERN
+from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_XRAY_TRACEID
+
+# currently only API Gateway v2 and Lambda support X-Ray tracing
+
+
+@markers.aws.validated
+@pytest.mark.skipif(
+    condition=is_old_provider(),
+    reason="not supported by the old provider",
+)
+def test_xray_trace_propagation_events_api_gateway(
+    aws_client,
+    create_role_with_policy,
+    create_lambda_function,
+    create_rest_apigw,
+    events_create_event_bus,
+    events_put_rule,
+    region_name,
+    cleanups,
+    account_id,
+):
+    # create lambda
+    function_name = f"test-function-{short_uid()}"
+    function_arn = create_lambda_function(
+        func_name=function_name,
+        handler_file=TEST_LAMBDA_AWS_PROXY_FORMAT,
+        handler="lambda_aws_proxy_format.handler",
+        runtime=Runtime.python3_12,
+    )["CreateFunctionResponse"]["FunctionArn"]
+
+    # create api gateway with lambda integration
+    # create rest api
+    api_id, api_name, root_id = create_rest_apigw(
+        name=f"test-api-{short_uid()}",
+        description="Test Integration with EventBridge X-Ray",
+    )
+
+    resource_id = aws_client.apigateway.create_resource(
+        restApiId=api_id, parentId=root_id, pathPart="test"
+    )["id"]
+
+    aws_client.apigateway.put_method(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        authorizationType="NONE",
+    )
+
+    # Lambda AWS_PROXY integration
+    aws_client.apigateway.put_integration(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        type="AWS_PROXY",
+        integrationHttpMethod="POST",
+        uri=f"arn:aws:apigateway:{region_name}:lambda:path/2015-03-31/functions/{function_arn}/invocations",
+    )
+
+    # Give permission to API Gateway to invoke Lambda
+    source_arn = f"arn:aws:execute-api:{region_name}:{account_id}:{api_id}/*/POST/test"
+    aws_client.lambda_.add_permission(
+        FunctionName=function_name,
+        StatementId=f"sid-{short_uid()}",
+        Action="lambda:InvokeFunction",
+        Principal="apigateway.amazonaws.com",
+        SourceArn=source_arn,
+    )
+
+    stage_name = "test"
+    aws_client.apigateway.create_deployment(restApiId=api_id, stageName=stage_name)
+
+    # Create event bus
+    event_bus_name = f"test-bus-{short_uid()}"
+    events_create_event_bus(Name=event_bus_name)
+
+    # Create rule
+    rule_name = f"test-rule-{short_uid()}"
+    event_pattern = {"source": ["test.source"], "detail-type": ["test.detail.type"]}
+    events_put_rule(
+        Name=rule_name,
+        EventBusName=event_bus_name,
+        EventPattern=json.dumps(event_pattern),
+    )
+
+    # Create an IAM Role for EventBridge to invoke API Gateway
+    assume_role_policy_document = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "events.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+
+    role_name, role_arn = create_role_with_policy(
+        effect="Allow",
+        actions="execute-api:Invoke",
+        assume_policy_doc=json.dumps(assume_role_policy_document),
+        resource=source_arn,
+        attach=False,  # Since we're using put_role_policy, not attach_role_policy
+    )
+
+    # Allow some time for IAM role propagation (only needed in AWS)
+    if is_aws_cloud():
+        time.sleep(10)
+
+    # Add the API Gateway as a target with the RoleArn
+    target_id = f"target-{short_uid()}"
+    api_target_arn = (
+        f"arn:aws:execute-api:{region_name}:{account_id}:{api_id}/{stage_name}/POST/test"
+    )
+    put_targets_response = aws_client.events.put_targets(
+        Rule=rule_name,
+        EventBusName=event_bus_name,
+        Targets=[
+            {
+                "Id": target_id,
+                "Arn": api_target_arn,
+                "RoleArn": role_arn,
+                "Input": json.dumps({"message": "Hello from EventBridge"}),
+                "RetryPolicy": {"MaximumRetryAttempts": 0},
+            }
+        ],
+    )
+    assert put_targets_response["FailedEntryCount"] == 0
+
+    ######
+    # Test
+    ######
+    # Enable X-Ray tracing for the aws_client
+    trace_id = "1-67f4141f-e1cd7672871da115129f8b19"
+    parent_id = "d0ee9531727135a0"
+    xray_trace_header = TraceHeader(root=trace_id, parent=parent_id, sampled=1)
+
+    def add_xray_header(request, **kwargs):
+        request.headers["X-Amzn-Trace-Id"] = xray_trace_header.to_header_str()
+
+    event_name = "before-send.events.*"
+    aws_client.events.meta.events.register(event_name, add_xray_header)
+
+    # make sure the hook gets cleaned up after the test
+    cleanups.append(lambda: aws_client.events.meta.events.unregister(event_name, add_xray_header))
+
+    event_entry = {
+        "EventBusName": event_bus_name,
+        "Source": "test.source",
+        "DetailType": "test.detail.type",
+        "Detail": json.dumps({"message": "Hello from EventBridge"}),
+    }
+    put_events_response = aws_client.events.put_events(Entries=[event_entry])
+    assert put_events_response["FailedEntryCount"] == 0
+
+    # Verify the Lambda invocation
+    events = retry(
+        check_expected_lambda_log_events_length,
+        retries=10,
+        sleep=10,
+        sleep_before=10 if is_aws_cloud() else 1,
+        function_name=function_name,
+        expected_length=1,
+        logs_client=aws_client.logs,
+    )
+
+    # TODO how to assert X-Ray trace ID correct propagation from eventbridge to api gateway if no X-Ray trace id is present in the event
+
+    lambda_trace_header = events[0]["headers"].get("X-Amzn-Trace-Id")
+    assert lambda_trace_header is not None
+    lambda_trace_id = re.search(r"Root=([^;]+)", lambda_trace_header).group(1)
+    assert lambda_trace_id == trace_id
+
+
+@markers.aws.validated
+@pytest.mark.skipif(
+    condition=is_old_provider(),
+    reason="not supported by the old provider",
+)
+def test_xray_trace_propagation_events_lambda(
+    create_lambda_function,
+    events_create_event_bus,
+    events_put_rule,
+    cleanups,
+    aws_client,
+):
+    function_name = f"lambda-func-{short_uid()}"
+    create_lambda_response = create_lambda_function(
+        handler_file=TEST_LAMBDA_XRAY_TRACEID,
+        func_name=function_name,
+        runtime=Runtime.python3_12,
+    )
+    lambda_function_arn = create_lambda_response["CreateFunctionResponse"]["FunctionArn"]
+
+    bus_name = f"bus-{short_uid()}"
+    events_create_event_bus(Name=bus_name)
+
+    rule_name = f"rule-{short_uid()}"
+    rule_arn = events_put_rule(
+        Name=rule_name,
+        EventBusName=bus_name,
+        EventPattern=json.dumps(TEST_EVENT_PATTERN),
+    )["RuleArn"]
+
+    aws_client.lambda_.add_permission(
+        FunctionName=function_name,
+        StatementId=f"{rule_name}-Event",
+        Action="lambda:InvokeFunction",
+        Principal="events.amazonaws.com",
+        SourceArn=rule_arn,
+    )
+
+    target_id = f"target-{short_uid()}"
+    aws_client.events.put_targets(
+        Rule=rule_name,
+        EventBusName=bus_name,
+        Targets=[{"Id": target_id, "Arn": lambda_function_arn}],
+    )
+
+    # Enable X-Ray tracing for the aws_client
+    trace_id = "1-67f4141f-e1cd7672871da115129f8b19"
+    parent_id = "d0ee9531727135a0"
+    xray_trace_header = TraceHeader(root=trace_id, parent=parent_id, sampled=1)
+
+    def add_xray_header(request, **kwargs):
+        request.headers["X-Amzn-Trace-Id"] = xray_trace_header.to_header_str()
+
+    event_name = "before-send.events.*"
+    aws_client.events.meta.events.register(event_name, add_xray_header)
+    # make sure the hook gets cleaned up after the test
+    cleanups.append(lambda: aws_client.events.meta.events.unregister(event_name, add_xray_header))
+
+    aws_client.events.put_events(
+        Entries=[
+            {
+                "EventBusName": bus_name,
+                "Source": TEST_EVENT_PATTERN["source"][0],
+                "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
+            }
+        ]
+    )
+
+    # Verify the Lambda invocation
+    events = retry(
+        check_expected_lambda_log_events_length,
+        retries=10,
+        sleep=10,
+        function_name=function_name,
+        expected_length=1,
+        logs_client=aws_client.logs,
+    )
+
+    # TODO how to assert X-Ray trace ID correct propagation from eventbridge to api lambda if no X-Ray trace id is present in the event
+
+    lambda_trace_header = events[0]["trace_id_inside_handler"]
+    assert lambda_trace_header is not None
+    lambda_trace_id = re.search(r"Root=([^;]+)", lambda_trace_header).group(1)
+    assert lambda_trace_id == trace_id
+
+
+@markers.aws.validated
+@pytest.mark.parametrize(
+    "bus_combination", [("default", "custom"), ("custom", "custom"), ("custom", "default")]
+)
+@pytest.mark.skipif(
+    condition=is_old_provider(),
+    reason="not supported by the old provider",
+)
+def test_xray_trace_propagation_events_events(
+    bus_combination,
+    create_lambda_function,
+    events_create_event_bus,
+    create_role_event_bus_source_to_bus_target,
+    region_name,
+    account_id,
+    events_put_rule,
+    cleanups,
+    aws_client,
+):
+    """
+    Event Bridge Bus Source to Event Bridge Bus Target to Lambda for asserting X-Ray trace propagation
+    """
+    # Create event buses
+    bus_source, bus_target = bus_combination
+    if bus_source == "default":
+        bus_name_source = "default"
+    if bus_source == "custom":
+        bus_name_source = f"test-event-bus-source-{short_uid()}"
+        events_create_event_bus(Name=bus_name_source)
+    if bus_target == "default":
+        bus_name_target = "default"
+        bus_arn_target = f"arn:aws:events:{region_name}:{account_id}:event-bus/default"
+    if bus_target == "custom":
+        bus_name_target = f"test-event-bus-target-{short_uid()}"
+        bus_arn_target = events_create_event_bus(Name=bus_name_target)["EventBusArn"]
+
+    # Create permission for event bus source to send events to event bus target
+    role_arn_bus_source_to_bus_target = create_role_event_bus_source_to_bus_target()
+
+    if is_aws_cloud():
+        time.sleep(10)  # required for role propagation
+
+    # Permission for event bus target to receive events from event bus source
+    aws_client.events.put_permission(
+        StatementId=f"TargetEventBusAccessPermission{short_uid()}",
+        EventBusName=bus_name_target,
+        Action="events:PutEvents",
+        Principal="*",
+    )
+
+    # Create rule source event bus to target
+    rule_name_source_to_target = f"test-rule-source-to-target-{short_uid()}"
+    events_put_rule(
+        Name=rule_name_source_to_target,
+        EventBusName=bus_name_source,
+        EventPattern=json.dumps(TEST_EVENT_PATTERN),
+    )
+
+    # Add target event bus as target
+    target_id_event_bus_target = f"test-target-source-events-{short_uid()}"
+    aws_client.events.put_targets(
+        Rule=rule_name_source_to_target,
+        EventBusName=bus_name_source,
+        Targets=[
+            {
+                "Id": target_id_event_bus_target,
+                "Arn": bus_arn_target,
+                "RoleArn": role_arn_bus_source_to_bus_target,
+            }
+        ],
+    )
+
+    # Create Lambda function
+    function_name = f"lambda-func-{short_uid()}"
+    create_lambda_response = create_lambda_function(
+        handler_file=TEST_LAMBDA_XRAY_TRACEID,
+        func_name=function_name,
+        runtime=Runtime.python3_12,
+    )
+    lambda_function_arn = create_lambda_response["CreateFunctionResponse"]["FunctionArn"]
+
+    # Connect Event Bus Target to Lambda
+    rule_name_lambda = f"rule-{short_uid()}"
+    rule_arn_lambda = events_put_rule(
+        Name=rule_name_lambda,
+        EventBusName=bus_name_target,
+        EventPattern=json.dumps(TEST_EVENT_PATTERN),
+    )["RuleArn"]
+
+    aws_client.lambda_.add_permission(
+        FunctionName=function_name,
+        StatementId=f"{rule_name_lambda}-Event",
+        Action="lambda:InvokeFunction",
+        Principal="events.amazonaws.com",
+        SourceArn=rule_arn_lambda,
+    )
+
+    target_id_lambda = f"target-{short_uid()}"
+    aws_client.events.put_targets(
+        Rule=rule_name_lambda,
+        EventBusName=bus_name_target,
+        Targets=[{"Id": target_id_lambda, "Arn": lambda_function_arn}],
+    )
+
+    ######
+    # Test
+    ######
+
+    # Enable X-Ray tracing for the aws_client
+    trace_id = "1-67f4141f-e1cd7672871da115129f8b19"
+    parent_id = "d0ee9531727135a0"
+    xray_trace_header = TraceHeader(root=trace_id, parent=parent_id, sampled=1)
+
+    def add_xray_header(request, **kwargs):
+        request.headers["X-Amzn-Trace-Id"] = xray_trace_header.to_header_str()
+
+    event_name = "before-send.events.*"
+    aws_client.events.meta.events.register(event_name, add_xray_header)
+    # make sure the hook gets cleaned up after the test
+    cleanups.append(lambda: aws_client.events.meta.events.unregister(event_name, add_xray_header))
+
+    aws_client.events.put_events(
+        Entries=[
+            {
+                "EventBusName": bus_name_source,
+                "Source": TEST_EVENT_PATTERN["source"][0],
+                "DetailType": TEST_EVENT_PATTERN["detail-type"][0],
+                "Detail": json.dumps(TEST_EVENT_DETAIL),
+            }
+        ]
+    )
+
+    # Verify the Lambda invocation
+    events = retry(
+        check_expected_lambda_log_events_length,
+        retries=10,
+        sleep=10,
+        function_name=function_name,
+        expected_length=1,
+        logs_client=aws_client.logs,
+    )
+
+    # TODO how to assert X-Ray trace ID correct propagation from eventbridge to eventbridge lambda if no X-Ray trace id is present in the event
+
+    lambda_trace_header = events[0]["trace_id_inside_handler"]
+    assert lambda_trace_header is not None
+    lambda_trace_id = re.search(r"Root=([^;]+)", lambda_trace_header).group(1)
+    assert lambda_trace_id == trace_id

--- a/tests/aws/services/events/test_x_ray_trace_propagation.validation.json
+++ b/tests/aws/services/events/test_x_ray_trace_propagation.validation.json
@@ -1,0 +1,17 @@
+{
+  "tests/aws/services/events/test_x_ray_trace_propagation.py::test_xray_trace_propagation_events_api_gateway": {
+    "last_validated_date": "2025-04-08T10:51:26+00:00"
+  },
+  "tests/aws/services/events/test_x_ray_trace_propagation.py::test_xray_trace_propagation_events_events[bus_combination0]": {
+    "last_validated_date": "2025-04-10T10:13:06+00:00"
+  },
+  "tests/aws/services/events/test_x_ray_trace_propagation.py::test_xray_trace_propagation_events_events[bus_combination1]": {
+    "last_validated_date": "2025-04-10T10:13:27+00:00"
+  },
+  "tests/aws/services/events/test_x_ray_trace_propagation.py::test_xray_trace_propagation_events_events[bus_combination2]": {
+    "last_validated_date": "2025-04-10T10:14:01+00:00"
+  },
+  "tests/aws/services/events/test_x_ray_trace_propagation.py::test_xray_trace_propagation_events_lambda": {
+    "last_validated_date": "2025-04-08T10:46:50+00:00"
+  }
+}

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -128,6 +128,7 @@ TEST_LAMBDA_PYTHON_MULTIPLE_HANDLERS = os.path.join(
 )
 TEST_LAMBDA_NOTIFIER = os.path.join(THIS_FOLDER, "functions/lambda_notifier.py")
 TEST_LAMBDA_CLOUDWATCH_LOGS = os.path.join(THIS_FOLDER, "functions/lambda_cloudwatch_logs.py")
+TEST_LAMBDA_XRAY_TRACEID = os.path.join(THIS_FOLDER, "functions/xray_tracing_traceid.py")
 
 PYTHON_TEST_RUNTIMES = RUNTIMES_AGGREGATED["python"]
 NODE_TEST_RUNTIMES = RUNTIMES_AGGREGATED["nodejs"]

--- a/tests/aws/services/ses/test_ses.py
+++ b/tests/aws/services/ses/test_ses.py
@@ -117,30 +117,6 @@ def setup_email_addresses(ses_verify_identity):
 
 
 @pytest.fixture
-def setup_sender_email_address(ses_verify_identity):
-    """
-    If the test is running against AWS then assume the email address passed is already
-    verified, and passes the given email address through. Otherwise, it generates one random
-    email address and verify them.
-    """
-
-    def inner(sender_email_address: Optional[str] = None) -> str:
-        if is_aws_cloud():
-            if sender_email_address is None:
-                raise ValueError(
-                    "sender_email_address must be specified to run this test against AWS"
-                )
-        else:
-            # overwrite the given parameters with localstack specific ones
-            sender_email_address = f"sender-{short_uid()}@example.com"
-            ses_verify_identity(sender_email_address)
-
-        return sender_email_address
-
-    return inner
-
-
-@pytest.fixture
 def add_snapshot_transformer_for_sns_event(snapshot):
     def _inner(sender_email, recipient_email, config_set_name):
         snapshot.add_transformers_list(

--- a/tests/aws/services/sqs/test_sqs.py
+++ b/tests/aws/services/sqs/test_sqs.py
@@ -16,10 +16,7 @@ from localstack.aws.api.lambda_ import Runtime
 from localstack.services.sqs.constants import DEFAULT_MAXIMUM_MESSAGE_SIZE, SQS_UUID_STRING_SEED
 from localstack.services.sqs.models import sqs_stores
 from localstack.services.sqs.provider import MAX_NUMBER_OF_MESSAGES
-from localstack.services.sqs.utils import (
-    parse_queue_url,
-    token_generator,
-)
+from localstack.services.sqs.utils import parse_queue_url
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.config import (
     SECONDARY_TEST_AWS_ACCESS_KEY_ID,
@@ -32,6 +29,7 @@ from localstack.utils.aws import arns
 from localstack.utils.aws.arns import get_partition
 from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.common import poll_condition, retry, short_uid, short_uid_from_seed, to_str
+from localstack.utils.strings import token_generator
 from localstack.utils.urls import localstack_host
 from tests.aws.services.lambda_.functions import lambda_integration
 from tests.aws.services.lambda_.test_lambda import TEST_LAMBDA_PYTHON

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py
@@ -1081,3 +1081,181 @@ class TestSfnApiAliasing:
         sfn_snapshot.match(
             "delete_state_machine_alias_response", delete_state_machine_alias_response
         )
+
+    @markers.aws.validated
+    def test_list_state_machine_aliases_pagination_invalid_next_token(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_client = aws_client.stepfunctions
+
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+
+        state_machine_name = f"state_machine_{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=json.dumps(definition),
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+
+        state_machine_arn = create_state_machine_response["stateMachineArn"]
+        state_machine_version_arn = create_state_machine_response["stateMachineVersionArn"]
+
+        state_machine_alias_name = f"AliasName-{short_uid()}"
+
+        sfn_snapshot.add_transformer(
+            RegexTransformer(state_machine_alias_name, "state_machine_alias_name")
+        )
+
+        create_state_machine_alias_response = create_state_machine_alias(
+            target_aws_client=aws_client,
+            description="create state machine alias description",
+            name=state_machine_alias_name,
+            routingConfiguration=[
+                RoutingConfigurationListItem(
+                    stateMachineVersionArn=state_machine_version_arn, weight=100
+                )
+            ],
+        )
+
+        sfn_snapshot.match(
+            "create_state_machine_alias_response", create_state_machine_alias_response
+        )
+
+        state_machine_alias_arn = create_state_machine_alias_response["stateMachineAliasArn"]
+        await_state_machine_alias_is_created(
+            stepfunctions_client=sfn_client,
+            state_machine_arn=state_machine_arn,
+            state_machine_alias_arn=state_machine_alias_arn,
+        )
+
+        with pytest.raises(Exception) as exc:
+            sfn_client.list_state_machine_aliases(
+                stateMachineArn=state_machine_arn, nextToken="InvalidToken"
+            )
+
+        sfn_snapshot.match(
+            "invalidTokenException",
+            {"exception_typename": exc.typename, "exception_value": exc.value},
+        )
+
+    @markers.aws.validated
+    @pytest.mark.parametrize("max_results", [0, 1])
+    def test_list_state_machine_aliases_pagination_max_results(
+        self,
+        create_state_machine_iam_role,
+        create_state_machine,
+        create_state_machine_alias,
+        max_results,
+        sfn_snapshot,
+        aws_client,
+    ):
+        sfn_client = aws_client.stepfunctions
+
+        sfn_role_arn = create_state_machine_iam_role(aws_client)
+        sfn_snapshot.add_transformer(RegexTransformer(sfn_role_arn, "sfn_role_arn"))
+
+        definition = BaseTemplate.load_sfn_template(BaseTemplate.BASE_PASS_RESULT)
+
+        state_machine_name = f"state_machine_test-{short_uid()}"
+        create_state_machine_response = create_state_machine(
+            target_aws_client=aws_client,
+            name=state_machine_name,
+            definition=json.dumps(definition),
+            roleArn=sfn_role_arn,
+            publish=True,
+        )
+
+        sfn_snapshot.add_transformer(
+            sfn_snapshot.transform.sfn_sm_create_arn(create_state_machine_response, 0)
+        )
+
+        state_machine_arn = create_state_machine_response["stateMachineArn"]
+        state_machine_version_arn = create_state_machine_response["stateMachineVersionArn"]
+
+        for i in range(3):
+            create_state_machine_alias_response = create_state_machine_alias(
+                target_aws_client=aws_client,
+                description=f"Description {i + 1} - create state machine alias",
+                name=f"AliasName-{i + 1}",
+                routingConfiguration=[
+                    RoutingConfigurationListItem(
+                        stateMachineVersionArn=state_machine_version_arn, weight=100
+                    )
+                ],
+            )
+
+            sfn_snapshot.match(
+                f"create_state_machine_alias_response-{i + 1}", create_state_machine_alias_response
+            )
+
+            definition["Comment"] = f"Comment {i + 1}"
+            sfn_client.update_state_machine(
+                stateMachineArn=state_machine_arn, definition=json.dumps(definition)
+            )
+
+            state_machine_alias_arn = create_state_machine_alias_response["stateMachineAliasArn"]
+            await_state_machine_alias_is_created(
+                stepfunctions_client=sfn_client,
+                state_machine_arn=state_machine_arn,
+                state_machine_alias_arn=state_machine_alias_arn,
+            )
+
+        with pytest.raises(Exception) as err:
+            sfn_client.list_state_machine_aliases(stateMachineArn=state_machine_arn, maxResults=-1)
+
+        sfn_snapshot.match("list_state_machine_aliases_max_results_-1_response", err.value)
+
+        with pytest.raises(Exception) as err:
+            sfn_client.list_state_machine_aliases(
+                stateMachineArn=state_machine_arn, maxResults=1001
+            )
+
+        sfn_snapshot.match(
+            "list_state_machine_aliases_max_results_1001_response", err.value.response
+        )
+
+        if max_results == 0:
+            list_state_machine_aliases_response = sfn_client.list_state_machine_aliases(
+                stateMachineArn=state_machine_arn, maxResults=0
+            )
+
+            sfn_snapshot.match(
+                "list_state_machine_aliases_max_results_0_response",
+                list_state_machine_aliases_response,
+            )
+
+        else:
+            list_state_machine_aliases_response = sfn_client.list_state_machine_aliases(
+                stateMachineArn=state_machine_arn, maxResults=1
+            )
+
+            sfn_snapshot.match(
+                "list_state_machine_aliases_max_results_1_response",
+                list_state_machine_aliases_response,
+            )
+
+            list_state_machine_aliases_response = sfn_client.list_state_machine_aliases(
+                stateMachineArn=state_machine_arn,
+                nextToken=list_state_machine_aliases_response.get("nextToken"),
+            )
+
+            sfn_snapshot.add_transformer(sfn_snapshot.transform.key_value("nextToken"))
+
+            sfn_snapshot.match(
+                "list_state_machine_aliases_next_token_response",
+                list_state_machine_aliases_response,
+            )

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.snapshot.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_create_alias_single_router_config": {
-    "recorded-date": "03-03-2025, 13:12:29",
+    "recorded-date": "09-04-2025, 20:23:57",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -13,7 +13,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_with_state_machine_arn": {
-    "recorded-date": "03-03-2025, 13:12:48",
+    "recorded-date": "09-04-2025, 20:24:12",
     "recorded-content": {
       "exception": {
         "exception_typename": "ValidationException",
@@ -22,7 +22,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_not_idempotent": {
-    "recorded-date": "03-03-2025, 13:13:02",
+    "recorded-date": "09-04-2025, 20:24:29",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -43,7 +43,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_idempotent_create_alias": {
-    "recorded-date": "03-03-2025, 13:13:16",
+    "recorded-date": "09-04-2025, 20:24:44",
     "recorded-content": {
       "create_state_machine_alias_response_attempt_0": {
         "creationDate": "datetime",
@@ -88,7 +88,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_router_configs": {
-    "recorded-date": "03-03-2025, 13:13:32",
+    "recorded-date": "09-04-2025, 20:25:01",
     "recorded-content": {
       "no_routing": {
         "exception_typename": "ParamValidationError",
@@ -125,7 +125,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_name": {
-    "recorded-date": "03-03-2025, 13:13:52",
+    "recorded-date": "09-04-2025, 20:25:16",
     "recorded-content": {
       "exception_for_name123": {
         "exception_typename": "ValidationException",
@@ -154,7 +154,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_delete_list": {
-    "recorded-date": "03-03-2025, 13:14:23",
+    "recorded-date": "09-04-2025, 20:25:46",
     "recorded-content": {
       "list_state_machine_aliases_response_empty": {
         "stateMachineAliases": [],
@@ -291,7 +291,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_invoke_describe_list": {
-    "recorded-date": "03-03-2025, 13:20:29",
+    "recorded-date": "09-04-2025, 20:26:23",
     "recorded-content": {
       "list_state_machine_aliases_response_empty": {
         "stateMachineAliases": [],
@@ -409,7 +409,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_update_describe": {
-    "recorded-date": "03-03-2025, 13:15:57",
+    "recorded-date": "09-04-2025, 20:27:40",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -474,7 +474,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_version_with_alias": {
-    "recorded-date": "03-03-2025, 13:16:42",
+    "recorded-date": "09-04-2025, 20:28:26",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -514,7 +514,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_revision_with_alias": {
-    "recorded-date": "03-03-2025, 13:34:23",
+    "recorded-date": "09-04-2025, 20:28:41",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -533,7 +533,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_no_such_alias_arn": {
-    "recorded-date": "03-03-2025, 13:37:24",
+    "recorded-date": "09-04-2025, 20:28:58",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -552,7 +552,7 @@
     }
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_update_no_such_alias_arn": {
-    "recorded-date": "03-03-2025, 15:00:26",
+    "recorded-date": "09-04-2025, 20:26:04",
     "recorded-content": {
       "create_state_machine_alias_response": {
         "creationDate": "datetime",
@@ -565,6 +565,212 @@
       "update_no_such_alias_arn": {
         "exception_typename": "ResourceNotFound",
         "exception_value": "An error occurred (ResourceNotFound) when calling the UpdateStateMachineAlias operation: Request references a resource that does not exist."
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_list_state_machine_aliases_pagination_invalid_next_token": {
+    "recorded-date": "09-04-2025, 20:29:13",
+    "recorded-content": {
+      "create_state_machine_alias_response": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:state_machine_alias_name",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalidTokenException": {
+        "exception_typename": "InvalidToken",
+        "exception_value": "An error occurred (InvalidToken) when calling the ListStateMachineAliases operation: Invalid Token: 'Invalid token'"
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_list_state_machine_aliases_pagination_max_results_1_next_token": {
+    "recorded-date": "09-04-2025, 18:46:18",
+    "recorded-content": {
+      "create_state_machine_alias_response-1": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response-2": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-2",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response-3": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-3",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_max_results_1_response": {
+        "nextToken": "<next-token:1>",
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_next_token_response": {
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-2"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-3"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_list_state_machine_aliases_pagination_max_results[0]": {
+    "recorded-date": "09-04-2025, 20:29:33",
+    "recorded-content": {
+      "create_state_machine_alias_response-1": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response-2": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-2",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response-3": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-3",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_max_results_-1_response": "Parameter validation failed:\nInvalid value for parameter maxResults, value: -1, valid min value: 0",
+      "list_state_machine_aliases_max_results_1001_response": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000"
+        },
+        "message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "list_state_machine_aliases_max_results_0_response": {
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-1"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-2"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-3"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_list_state_machine_aliases_pagination_max_results[1]": {
+    "recorded-date": "09-04-2025, 20:29:54",
+    "recorded-content": {
+      "create_state_machine_alias_response-1": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response-2": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-2",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_state_machine_alias_response-3": {
+        "creationDate": "datetime",
+        "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-3",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_max_results_-1_response": "Parameter validation failed:\nInvalid value for parameter maxResults, value: -1, valid min value: 0",
+      "list_state_machine_aliases_max_results_1001_response": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000"
+        },
+        "message": "1 validation error detected: Value '1001' at 'maxResults' failed to satisfy constraint: Member must have value less than or equal to 1000",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "list_state_machine_aliases_max_results_1_response": {
+        "nextToken": "<next-token:1>",
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_state_machine_aliases_next_token_response": {
+        "stateMachineAliases": [
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-2"
+          },
+          {
+            "creationDate": "datetime",
+            "stateMachineAliasArn": "arn:<partition>:states:<region>:111111111111:stateMachine:<ArnPart_0idx>:AliasName-3"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   }

--- a/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.validation.json
+++ b/tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.validation.json
@@ -1,41 +1,59 @@
 {
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_create_alias_single_router_config": {
-    "last_validated_date": "2025-03-03T13:12:29+00:00"
+    "last_validated_date": "2025-04-09T20:23:57+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_delete_list": {
-    "last_validated_date": "2025-03-03T13:14:23+00:00"
+    "last_validated_date": "2025-04-09T20:25:46+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_invoke_describe_list": {
-    "last_validated_date": "2025-03-03T13:20:29+00:00"
+    "last_validated_date": "2025-04-09T20:26:23+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_base_lifecycle_create_update_describe": {
-    "last_validated_date": "2025-03-03T13:15:57+00:00"
+    "last_validated_date": "2025-04-09T20:27:40+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_no_such_alias_arn": {
-    "last_validated_date": "2025-03-03T13:37:24+00:00"
+    "last_validated_date": "2025-04-09T20:28:58+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_revision_with_alias": {
-    "last_validated_date": "2025-03-03T13:34:23+00:00"
+    "last_validated_date": "2025-04-09T20:28:41+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_delete_version_with_alias": {
-    "last_validated_date": "2025-03-03T13:16:42+00:00"
+    "last_validated_date": "2025-04-09T20:28:26+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_name": {
-    "last_validated_date": "2025-03-03T13:13:52+00:00"
+    "last_validated_date": "2025-04-09T20:25:16+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_invalid_router_configs": {
-    "last_validated_date": "2025-03-03T13:13:32+00:00"
+    "last_validated_date": "2025-04-09T20:25:01+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_not_idempotent": {
-    "last_validated_date": "2025-03-03T13:13:02+00:00"
+    "last_validated_date": "2025-04-09T20:24:29+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_error_create_alias_with_state_machine_arn": {
-    "last_validated_date": "2025-03-03T13:12:48+00:00"
+    "last_validated_date": "2025-04-09T20:24:12+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_idempotent_create_alias": {
-    "last_validated_date": "2025-03-03T13:13:16+00:00"
+    "last_validated_date": "2025-04-09T20:24:44+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_list_state_machine_aliases_pagination": {
+    "last_validated_date": "2025-04-07T16:51:07+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_list_state_machine_aliases_pagination_invalid_next_token": {
+    "last_validated_date": "2025-04-09T20:29:13+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_list_state_machine_aliases_pagination_max_results[0]": {
+    "last_validated_date": "2025-04-09T20:29:33+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_list_state_machine_aliases_pagination_max_results[1]": {
+    "last_validated_date": "2025-04-09T20:29:54+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_list_state_machine_aliases_pagination_max_results_0": {
+    "last_validated_date": "2025-04-09T17:36:29+00:00"
+  },
+  "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_list_state_machine_aliases_pagination_max_results_1_next_token": {
+    "last_validated_date": "2025-04-09T18:46:18+00:00"
   },
   "tests/aws/services/stepfunctions/v2/test_sfn_api_aliasing.py::TestSfnApiAliasing::test_update_no_such_alias_arn": {
-    "last_validated_date": "2025-03-03T15:00:26+00:00"
+    "last_validated_date": "2025-04-09T20:26:04+00:00"
   }
 }

--- a/tests/aws/services/sts/test_sts.snapshot.json
+++ b/tests/aws/services/sts/test_sts.snapshot.json
@@ -69,5 +69,143 @@
         }
       }
     }
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSAssumeRoleTagging::test_assume_role_tag_validation": {
+    "recorded-date": "10-04-2025, 08:53:12",
+    "recorded-content": {
+      "role-1": {
+        "Role": {
+          "Arn": "arn:<partition>:iam::111111111111:role/<role-name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole",
+                  "sts:TagSession"
+                ],
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "111111111111"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "RoleId": "<role-id:1>",
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalid-transitive-tag-keys": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "The specified transitive tag key must be included in the requested tags.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "duplicate-tag-keys-different-casing": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "Duplicate tag keys found. Please note that Tag keys are case insensitive.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSAssumeRoleTagging::test_iam_role_chaining_override_transitive_tags": {
+    "recorded-date": "10-04-2025, 08:53:00",
+    "recorded-content": {
+      "role-1": {
+        "Role": {
+          "Arn": "arn:<partition>:iam::111111111111:role/<role-name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole",
+                  "sts:TagSession"
+                ],
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "111111111111"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "RoleId": "<role-id:1>",
+          "RoleName": "<role-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "role-2": {
+        "Role": {
+          "Arn": "arn:<partition>:iam::111111111111:role/<role-name:2>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole",
+                  "sts:TagSession"
+                ],
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "111111111111"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "<datetime>",
+          "Path": "/",
+          "RoleId": "<role-id:2>",
+          "RoleName": "<role-name:2>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "override-transitive-tag-error": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "One of the specified transitive tag keys can't be set because it conflicts with a transitive tag key from the calling session.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "override-transitive-tag-case-ignore-error": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Message": "One of the specified transitive tag keys can't be set because it conflicts with a transitive tag key from the calling session.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/sts/test_sts.validation.json
+++ b/tests/aws/services/sts/test_sts.validation.json
@@ -1,8 +1,23 @@
 {
+  "tests/aws/services/sts/test_sts.py::TestSTSAssumeRoleTagging::test_assume_role_tag_validation": {
+    "last_validated_date": "2025-04-10T08:53:12+00:00"
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSAssumeRoleTagging::test_iam_role_chaining_override_transitive_tags": {
+    "last_validated_date": "2025-04-10T08:53:00+00:00"
+  },
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role": {
     "last_validated_date": "2024-06-05T17:23:49+00:00"
   },
+  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role_invalid_tags": {
+    "last_validated_date": "2025-04-09T14:30:56+00:00"
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_assume_role_tag_validation": {
+    "last_validated_date": "2025-04-10T08:31:58+00:00"
+  },
   "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_get_federation_token": {
     "last_validated_date": "2024-06-05T13:39:17+00:00"
+  },
+  "tests/aws/services/sts/test_sts.py::TestSTSIntegrations::test_iam_role_chaining_override_transitive_tags": {
+    "last_validated_date": "2025-04-10T08:08:37+00:00"
   }
 }

--- a/tests/aws/services/transcribe/test_transcribe.snapshot.json
+++ b/tests/aws/services/transcribe/test_transcribe.snapshot.json
@@ -893,5 +893,32 @@
     "recorded-content": {
       "err_speaker_labels_diarization": "Parameter validation failed:\nInvalid value for parameter Settings.MaxSpeakerLabels, value: 1, valid min value: 2"
     }
+  },
+  "tests/aws/services/transcribe/test_transcribe.py::TestTranscribe::test_transcribe_error_invalid_length": {
+    "recorded-date": "12-04-2025, 16:02:39",
+    "recorded-content": {
+      "TranscribeErrorInvalidLength": {
+        "TranscriptionJob": {
+          "CreationTime": "datetime",
+          "FailureReason": "Invalid file size: file size too large. Maximum audio duration is 4.000000 hours.Check the length of the file and try your request again.",
+          "LanguageCode": "en-GB",
+          "Media": {
+            "MediaFileUri": "s3:/<test-bucket>/test-clip.wav"
+          },
+          "Settings": {
+            "ChannelIdentification": false,
+            "ShowAlternatives": false
+          },
+          "StartTime": "datetime",
+          "Transcript": {},
+          "TranscriptionJobName": "<transcription-job:1>",
+          "TranscriptionJobStatus": "FAILED"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/transcribe/test_transcribe.validation.json
+++ b/tests/aws/services/transcribe/test_transcribe.validation.json
@@ -11,6 +11,9 @@
   "tests/aws/services/transcribe/test_transcribe.py::TestTranscribe::test_list_transcription_jobs": {
     "last_validated_date": "2023-10-06T15:11:25+00:00"
   },
+  "tests/aws/services/transcribe/test_transcribe.py::TestTranscribe::test_transcribe_error_invalid_length": {
+    "last_validated_date": "2025-04-12T16:02:38+00:00"
+  },
   "tests/aws/services/transcribe/test_transcribe.py::TestTranscribe::test_transcribe_error_speaker_labels": {
     "last_validated_date": "2025-03-19T15:42:06+00:00"
   },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,44 +20,6 @@ pytest_plugins = [
 ]
 
 
-# FIXME: remove this once https://github.com/csernazs/pytest-httpserver/pull/411 is merged
-def pytest_sessionstart(session):
-    import threading
-
-    try:
-        from pytest_httpserver import HTTPServer, HTTPServerError
-        from werkzeug import Request
-        from werkzeug.serving import make_server
-
-        from localstack.utils.patch import Patch
-
-        def start_non_daemon_thread(self) -> None:
-            if self.is_running():
-                raise HTTPServerError("Server is already running")
-
-            app = Request.application(self.application)
-
-            self.server = make_server(
-                self.host,
-                self.port,
-                app,
-                ssl_context=self.ssl_context,
-                threaded=self.threaded,
-            )
-
-            self.port = self.server.port  # Update port (needed if `port` was set to 0)
-            self.server_thread = threading.Thread(target=self.thread_target, daemon=True)
-            self.server_thread.start()
-
-        patch = Patch(name="start", obj=HTTPServer, new=start_non_daemon_thread)
-        patch.apply()
-
-    except ImportError:
-        # this will be executed in the CLI tests as well, where we don't have the pytest_httpserver dependency
-        # skip in that case
-        pass
-
-
 @pytest.fixture(scope="session")
 def aws_session():
     """

--- a/tests/unit/cli/test_profiles.py
+++ b/tests/unit/cli/test_profiles.py
@@ -1,18 +1,148 @@
 import os
 import sys
 
-from localstack.cli.profiles import set_profile_from_sys_argv
+from localstack.cli.profiles import set_and_remove_profile_from_sys_argv
+
+
+def profile_test(monkeypatch, input_args, expected_profile, expected_argv):
+    monkeypatch.setattr(sys, "argv", input_args)
+    monkeypatch.setenv("CONFIG_PROFILE", "")
+    set_and_remove_profile_from_sys_argv()
+    assert os.environ["CONFIG_PROFILE"] == expected_profile
+    assert sys.argv == expected_argv
 
 
 def test_profiles_equals_notation(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["--profile=non-existing-test-profile"])
-    monkeypatch.setenv("CONFIG_PROFILE", "")
-    set_profile_from_sys_argv()
-    assert os.environ["CONFIG_PROFILE"] == "non-existing-test-profile"
+    profile_test(
+        monkeypatch,
+        input_args=["--profile=non-existing-test-profile"],
+        expected_profile="non-existing-test-profile",
+        expected_argv=[],
+    )
 
 
 def test_profiles_separate_args_notation(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["--profile", "non-existing-test-profile"])
-    monkeypatch.setenv("CONFIG_PROFILE", "")
-    set_profile_from_sys_argv()
-    assert os.environ["CONFIG_PROFILE"] == "non-existing-test-profile"
+    profile_test(
+        monkeypatch,
+        input_args=["--profile", "non-existing-test-profile"],
+        expected_profile="non-existing-test-profile",
+        expected_argv=[],
+    )
+
+
+def test_p_equals_notation(monkeypatch):
+    profile_test(
+        monkeypatch,
+        input_args=["-p=non-existing-test-profile"],
+        expected_profile="non-existing-test-profile",
+        expected_argv=["-p=non-existing-test-profile"],
+    )
+
+
+def test_p_separate_args_notation(monkeypatch):
+    profile_test(
+        monkeypatch,
+        input_args=["-p", "non-existing-test-profile"],
+        expected_profile="non-existing-test-profile",
+        expected_argv=["-p", "non-existing-test-profile"],
+    )
+
+
+def test_profiles_args_before_and_after(monkeypatch):
+    profile_test(
+        monkeypatch,
+        input_args=["cli", "-D", "--profile=non-existing-test-profile", "start"],
+        expected_profile="non-existing-test-profile",
+        expected_argv=["cli", "-D", "start"],
+    )
+
+
+def test_profiles_args_before_and_after_separate(monkeypatch):
+    profile_test(
+        monkeypatch,
+        input_args=["cli", "-D", "--profile", "non-existing-test-profile", "start"],
+        expected_profile="non-existing-test-profile",
+        expected_argv=["cli", "-D", "start"],
+    )
+
+
+def test_p_args_before_and_after_separate(monkeypatch):
+    profile_test(
+        monkeypatch,
+        input_args=["cli", "-D", "-p", "non-existing-test-profile", "start"],
+        expected_profile="non-existing-test-profile",
+        expected_argv=["cli", "-D", "-p", "non-existing-test-profile", "start"],
+    )
+
+
+def test_profiles_args_multiple(monkeypatch):
+    profile_test(
+        monkeypatch,
+        input_args=[
+            "cli",
+            "--profile",
+            "non-existing-test-profile",
+            "start",
+            "--profile",
+            "another-profile",
+        ],
+        expected_profile="another-profile",
+        expected_argv=["cli", "start"],
+    )
+
+
+def test_p_args_multiple(monkeypatch):
+    profile_test(
+        monkeypatch,
+        input_args=[
+            "cli",
+            "-p",
+            "non-existing-test-profile",
+            "start",
+            "-p",
+            "another-profile",
+        ],
+        expected_profile="non-existing-test-profile",
+        expected_argv=[
+            "cli",
+            "-p",
+            "non-existing-test-profile",
+            "start",
+            "-p",
+            "another-profile",
+        ],
+    )
+
+
+def test_p_and_profile_args(monkeypatch):
+    profile_test(
+        monkeypatch,
+        input_args=[
+            "cli",
+            "-p",
+            "non-existing-test-profile",
+            "start",
+            "--profile",
+            "the_profile",
+            "-p",
+            "another-profile",
+        ],
+        expected_profile="the_profile",
+        expected_argv=[
+            "cli",
+            "-p",
+            "non-existing-test-profile",
+            "start",
+            "-p",
+            "another-profile",
+        ],
+    )
+
+
+def test_trailing_p_argument(monkeypatch):
+    profile_test(
+        monkeypatch,
+        input_args=["cli", "start", "-p"],
+        expected_profile="",
+        expected_argv=["cli", "start", "-p"],
+    )


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `ab2d6a4..9e84b8d`
**Files Changed:** 77 (49 programming files)
**Programming Ratio:** 63.6%

**Commits included:**
- Bump moto-ext to 5.1.3.post1 (#12499)
- CloudFormation Engine V2: Improve delta computation of properties, conditional resolution, and physical resources ref (#12533)
- [AWS][Transcribe] Adding fix for validating Audio length (#12450)
- CFn executor v2: provide previous payload correctly (#12511)
- CloudFormation Engine v2: Base Mappings and Conditions tests for Update Graph and PreProc (#12527)
- StepFunctions: ListStateMachineAliases pagination support (#12496)
- Added GH action to build community image (#12515)
- Upgrade dependencies, remove pytest-httpserver patch (#12524)
- Allow --profile to be specified anywhere on the CLI command line (#12500)
- Bump python from 3.11.11-slim-bookworm to 3.11.12-slim-bookworm in the docker-base-images group (#12523)
... and 5 more commits